### PR TITLE
refactor(capacities): use capacities as map as returned by server

### DIFF
--- a/application/src/main/frontend/src/app/facilities/capacitiesTable.js
+++ b/application/src/main/frontend/src/app/facilities/capacitiesTable.js
@@ -8,7 +8,12 @@
                 capacities: '='
             },
             templateUrl: 'facilities/capacitiesTable.tpl.html',
-            transclude: false
+            transclude: false,
+            link: function(scope) {
+                scope.thereAreCapacities = function() {
+                    return !_.isEmpty(scope.capacities);
+                };
+            }
         };
     });
 })();

--- a/application/src/main/frontend/src/app/facilities/capacitiesTable.tpl.html
+++ b/application/src/main/frontend/src/app/facilities/capacitiesTable.tpl.html
@@ -1,4 +1,4 @@
-<div class="panel panel-default" ng-show="capacities">
+<div class="panel panel-default" ng-show="thereAreCapacities()">
 	<table class="table table-bordered table-striped table-condensed">
 		<thead>
 		<tr>
@@ -8,8 +8,8 @@
 		</tr>
 		</thead>
 		<tbody>
-		<tr ng-repeat="capacity in capacities">
-			<td>{{'facilities.capacity.' + capacity.capacityType | translate}}</td>
+		<tr ng-repeat="(capacityType, capacity) in capacities">
+			<td>{{'facilities.capacity.' + capacityType | translate}}</td>
 			<td>
 				{{capacity.built}}
 			</td>

--- a/application/src/main/frontend/src/app/facilities/facilityEdit.js
+++ b/application/src/main/frontend/src/app/facilities/facilityEdit.js
@@ -46,10 +46,7 @@
     });
 
     m.controller('FacilityEditCtrl', function($state, FacilityResource, capacityTypes, facility) {
-
-        facility.capacities = _.map(capacityTypes, function(capacityType) {
-            return FacilityResource.getOrCreateCapacity(facility, capacityType);
-        });
+        this.capacityTypes = capacityTypes;
 
         facility.aliases = _.map(facility.aliases, function(a) { return { text: a }; });
 

--- a/application/src/main/frontend/src/app/facilities/facilityEdit.tpl.html
+++ b/application/src/main/frontend/src/app/facilities/facilityEdit.tpl.html
@@ -38,13 +38,13 @@
 							</tr>
 						</thead>
 						<tbody>
-							<tr ng-repeat="capacity in editCtrl.facility.capacities">
-								<td>{{'facilities.capacity.' + capacity.capacityType | translate}}</td>
+							<tr ng-repeat="capacityType in editCtrl.capacityTypes">
+								<td>{{'facilities.capacity.' + capacityType | translate}}</td>
 								<td>
-									<input type="number" class="form-control" ng-model="capacity.built" min="0">
+									<input type="number" class="form-control" ng-model="editCtrl.facility.capacities[capacityType].built" min="0">
 								</td>
 								<td>
-									<input type="number" class="form-control" ng-model="capacity.unavailable" min="0">
+									<input type="number" class="form-control" ng-model="editCtrl.facility.capacities[capacityType].unavailable" min="0">
 								</td>
 							</tr>
 						</tbody>

--- a/application/src/main/frontend/src/common/services/FacilityResource.js
+++ b/application/src/main/frontend/src/common/services/FacilityResource.js
@@ -1,42 +1,12 @@
 (function() {
     var m = angular.module('parkandride.FacilityResource', []);
 
-    function buildCapacities(data) {
-        return _.reduce(
-            data,
-            function(target, capacity, key) {
-                var copy = _.clone(capacity);
-                copy.capacityType = key;
-                target.push(copy);
-                return target;
-            },
-            []);
-    }
-
-    function capacitiesToData(capacities) {
-        return _.reduce(
-            capacities,
-            function(target, capacity) {
-                if (capacity.built > 0) {
-                    var copy = _.clone(capacity);
-                    delete copy.capacityType;
-                    target[capacity.capacityType] = copy;
-                }
-                return target;
-            },
-            {});
-    }
-
-    function buildFacility(data) {
-        var copy = _.clone(data);
-        copy.capacities = buildCapacities(data.capacities);
-        return copy;
-    }
-
-    function facilityToData(facility) {
-        var copy = _.clone(facility);
-        copy.capacities = capacitiesToData(facility.capacities);
-        return copy;
+    function cleanupCapacities(capacities) {
+        for (var capacityType in capacities) {
+            if (!(capacities[capacityType] &&  capacities[capacityType].built && capacities[capacityType].built >= 1)) {
+                delete capacities[capacityType];
+            }
+        }
     }
 
     m.factory('FacilityResource', function($http, $q) {
@@ -49,10 +19,6 @@
             };
         };
 
-        api.getOrCreateCapacity = function(facility, capacityType) {
-            return _.find(facility.capacities, function(c) { return c.capacityType == capacityType; }) || { capacityType: capacityType };
-        };
-
         api.listFacilities = function() {
             return $http.get("/api/facilities").then(function(response) {
                 return response.data.results;
@@ -61,18 +27,18 @@
 
         api.getFacility = function(id) {
             return $http.get("/api/facilities/" + id).then(function(response){
-                return buildFacility(response.data);
+                return response.data;
             });
         };
 
-        api.save = function(newFacility) {
-            var data = facilityToData(newFacility);
-            if (data.id) {
-                return $http.put("/api/facilities/" + data.id, data).then(function(response){
+        api.save = function(facility) {
+            cleanupCapacities(facility.capacities);
+            if (facility.id) {
+                return $http.put("/api/facilities/" + facility.id, facility).then(function(response){
                     return response.data.id;
                 });
             } else {
-                return $http.post("/api/facilities", data).then(function(response){
+                return $http.post("/api/facilities", facility).then(function(response){
                     return response.data.id;
                 });
             }
@@ -89,16 +55,14 @@
         api.summarizeFacilities = function(facilityIds) {
             if (_.isEmpty(facilityIds)){
                 var deferred = $q.defer();
-                deferred.resolve({ facilityCount: 0, capacities: [] });
+                deferred.resolve({ facilityCount: 0, capacities: {} });
                 return deferred.promise;
             }
 
             return $http.get("/api/facilities", {
                 params: { summary: true, ids: facilityIds }
             }).then(function(response) {
-                var clone = _.cloneDeep(response.data);
-                clone.capacities = buildCapacities(clone.capacities);
-                return clone;
+                return response.data;
             });
         };
 


### PR DESCRIPTION
It's simpler to use capacities as object/map as returned by the server, instead of converting it to and fro array.
