### PR TITLE
fix(modals): don't close modal when clicking outside modal window

### DIFF
--- a/application/src/main/frontend/src/app/contacts/contacts.js
+++ b/application/src/main/frontend/src/app/contacts/contacts.js
@@ -62,7 +62,8 @@
                     create: function() {
                         return create;
                     }
-                }
+                },
+                backdrop: 'static'
             });
             return modalInstance.result;
         };

--- a/application/src/main/frontend/src/app/facilities/facilityMap.js
+++ b/application/src/main/frontend/src/app/facilities/facilityMap.js
@@ -149,7 +149,8 @@
                             mode: function() {
                                 return mode;
                             }
-                        }
+                        },
+                        backdrop: 'static'
                     });
                     return modalInstance.result;
                 };

--- a/application/src/main/frontend/src/app/operators/operators.js
+++ b/application/src/main/frontend/src/app/operators/operators.js
@@ -55,7 +55,8 @@
                     create: function() {
                         return create;
                     }
-                }
+                },
+                backdrop: 'static'
             });
             return modalInstance.result;
         };


### PR DESCRIPTION
Implemented for port, contact and operator modals. Login modal can be closed by clicking outside modal window.