### PR TITLE
Autoscaling deployment script

### DIFF
--- a/etc/scripts/gocd/deploy/deploy-asg.sh
+++ b/etc/scripts/gocd/deploy/deploy-asg.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu
+: ${ENV:?}
+: ${VAULT_PASSWORD:?}
+set -x
+
+VERSION=`cat version`
+BINARY=`readlink -f staging/fi/hsl/parkandride/parkandride-application/$VERSION/parkandride-application-$VERSION.jar`
+
+cd deploy
+
+echo '#!/bin/bash
+set -eu
+echo "$VAULT_PASSWORD"
+' > vault-password
+chmod a+x vault-password
+
+eval `ssh-agent -s`
+ssh-add "$HOME/hsl-liipi.pem"
+
+./ansible-playbook full-asg-deploy.yml -e env=$ENV -e "app_binary=$BINARY"


### PR DESCRIPTION
Run `deploy-asg.sh` instead of current `deploy.sh` to deploy with auto scaling group configuration.

This just provides the script. The CI configuration change to actually run the new script needs to be done separately.