### PR TITLE
LIIP-249: Save prediction history for each predictor separately

### DIFF
--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QCapacityType.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QCapacityType.java
@@ -39,8 +39,6 @@ public class QCapacityType extends RelationalPathSpatial<QCapacityType> {
 
     public final com.mysema.query.sql.ForeignKey<QPricing> _pricingCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
 
-    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
-
     public final com.mysema.query.sql.ForeignKey<QFacilityUtilization> _facilityUtilizationCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
 
     public QCapacityType(String variable) {

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
@@ -123,8 +123,6 @@ public class QFacility extends RelationalPathSpatial<QFacility> {
 
     public final com.mysema.query.sql.ForeignKey<QUnavailableCapacity> _unavailableCapacityFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
-    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
-
     public final com.mysema.query.sql.ForeignKey<QFacilityPrediction> _facilityPredictionFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
     public final com.mysema.query.sql.ForeignKey<QFacilityPaymentMethod> _facilityPaymentMethodFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityPredictionHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityPredictionHistory.java
@@ -5,7 +5,6 @@ import com.mysema.query.sql.spatial.RelationalPathSpatial;
 import com.mysema.query.types.Path;
 import com.mysema.query.types.PathMetadata;
 import com.mysema.query.types.path.DateTimePath;
-import com.mysema.query.types.path.EnumPath;
 import com.mysema.query.types.path.NumberPath;
 
 import javax.annotation.Generated;
@@ -25,25 +24,17 @@ public class QFacilityPredictionHistory extends RelationalPathSpatial<QFacilityP
 
     public static final QFacilityPredictionHistory facilityPredictionHistory = new QFacilityPredictionHistory("FACILITY_PREDICTION_HISTORY");
 
-    public final EnumPath<fi.hsl.parkandride.core.domain.CapacityType> capacityType = createEnum("capacityType", fi.hsl.parkandride.core.domain.CapacityType.class);
-
-    public final NumberPath<Long> facilityId = createNumber("facilityId", Long.class);
-
     public final NumberPath<Integer> forecastDistanceInMinutes = createNumber("forecastDistanceInMinutes", Integer.class);
+
+    public final NumberPath<Long> predictorId = createNumber("predictorId", Long.class);
 
     public final NumberPath<Integer> spacesAvailable = createNumber("spacesAvailable", Integer.class);
 
     public final DateTimePath<org.joda.time.DateTime> ts = createDateTime("ts", org.joda.time.DateTime.class);
 
-    public final EnumPath<fi.hsl.parkandride.core.domain.Usage> usage = createEnum("usage", fi.hsl.parkandride.core.domain.Usage.class);
+    public final com.mysema.query.sql.PrimaryKey<QFacilityPredictionHistory> constraint34b = createPrimaryKey(forecastDistanceInMinutes, predictorId, ts);
 
-    public final com.mysema.query.sql.PrimaryKey<QFacilityPredictionHistory> constraint34 = createPrimaryKey(capacityType, facilityId, forecastDistanceInMinutes, ts, usage);
-
-    public final com.mysema.query.sql.ForeignKey<QUsage> facilityPredictionHistoryUsageFk = createForeignKey(usage, "NAME");
-
-    public final com.mysema.query.sql.ForeignKey<QCapacityType> facilityPredictionHistoryCapacityTypeFk = createForeignKey(capacityType, "NAME");
-
-    public final com.mysema.query.sql.ForeignKey<QFacility> facilityPredictionHistoryFacilityIdFk = createForeignKey(facilityId, "ID");
+    public final com.mysema.query.sql.ForeignKey<QPredictor> facilityPredictionHistoryPredictorIdFk = createForeignKey(predictorId, "ID");
 
     public QFacilityPredictionHistory(String variable) {
         super(QFacilityPredictionHistory.class, forVariable(variable), "PUBLIC", "FACILITY_PREDICTION_HISTORY");
@@ -66,12 +57,10 @@ public class QFacilityPredictionHistory extends RelationalPathSpatial<QFacilityP
     }
 
     public void addMetadata() {
-        addMetadata(capacityType, ColumnMetadata.named("CAPACITY_TYPE").withIndex(2).ofType(Types.VARCHAR).withSize(64).notNull());
-        addMetadata(facilityId, ColumnMetadata.named("FACILITY_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
-        addMetadata(forecastDistanceInMinutes, ColumnMetadata.named("FORECAST_DISTANCE_IN_MINUTES").withIndex(5).ofType(Types.INTEGER).withSize(10).notNull());
-        addMetadata(spacesAvailable, ColumnMetadata.named("SPACES_AVAILABLE").withIndex(6).ofType(Types.INTEGER).withSize(10).notNull());
-        addMetadata(ts, ColumnMetadata.named("TS").withIndex(4).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
-        addMetadata(usage, ColumnMetadata.named("USAGE").withIndex(3).ofType(Types.VARCHAR).withSize(64).notNull());
+        addMetadata(forecastDistanceInMinutes, ColumnMetadata.named("FORECAST_DISTANCE_IN_MINUTES").withIndex(3).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(predictorId, ColumnMetadata.named("PREDICTOR_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(spacesAvailable, ColumnMetadata.named("SPACES_AVAILABLE").withIndex(4).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(ts, ColumnMetadata.named("TS").withIndex(2).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
     }
 
 }

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QPredictor.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QPredictor.java
@@ -51,6 +51,8 @@ public class QPredictor extends RelationalPathSpatial<QPredictor> {
 
     public final com.mysema.query.sql.ForeignKey<QUsage> predictorUsageFk = createForeignKey(usage, "NAME");
 
+    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryPredictorIdFk = createInvForeignKey(id, "PREDICTOR_ID");
+
     public QPredictor(String variable) {
         super(QPredictor.class, forVariable(variable), "PUBLIC", "PREDICTOR");
         addMetadata();

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QUsage.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QUsage.java
@@ -37,8 +37,6 @@ public class QUsage extends RelationalPathSpatial<QUsage> {
 
     public final com.mysema.query.sql.ForeignKey<QFacilityUtilization> _facilityUtilizationUsageFk = createInvForeignKey(name, "USAGE");
 
-    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryUsageFk = createInvForeignKey(name, "USAGE");
-
     public final com.mysema.query.sql.ForeignKey<QUnavailableCapacity> _unavailableCapacityUsageFk = createInvForeignKey(name, "USAGE");
 
     public final com.mysema.query.sql.ForeignKey<QPredictor> _predictorUsageFk = createInvForeignKey(name, "USAGE");

--- a/application/src/main/java/fi/hsl/parkandride/config/JdbcConfiguration.java
+++ b/application/src/main/java/fi/hsl/parkandride/config/JdbcConfiguration.java
@@ -147,9 +147,6 @@ public class JdbcConfiguration {
         conf.register("FACILITY_PREDICTION", "CAPACITY_TYPE", new EnumByNameType<>(CapacityType.class));
         conf.register("FACILITY_PREDICTION", "USAGE", new EnumByNameType<>(Usage.class));
 
-        conf.register("FACILITY_PREDICTION_HISTORY", "CAPACITY_TYPE", new EnumByNameType<>(CapacityType.class));
-        conf.register("FACILITY_PREDICTION_HISTORY", "USAGE", new EnumByNameType<>(Usage.class));
-
         conf.register("FACILITY_SERVICE", "SERVICE", new EnumByNameType<>(Service.class));
 
         conf.register("FACILITY_PAYMENT_METHOD", "PAYMENT_METHOD", new EnumByNameType<>(PaymentMethod.class));

--- a/application/src/main/java/fi/hsl/parkandride/core/back/PredictionRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/PredictionRepository.java
@@ -18,11 +18,11 @@ public interface PredictionRepository {
     Hours PREDICTION_WINDOW = Hours.hours(24);
     Minutes PREDICTION_RESOLUTION = Minutes.minutes(5);
 
-    void updatePredictions(PredictionBatch predictions);
+    void updatePredictions(PredictionBatch predictions, Long predictorId);
 
     Optional<PredictionBatch> getPrediction(UtilizationKey utilizationKey, DateTime time);
 
     List<PredictionBatch> getPredictionsByFacility(Long facilityId, DateTime time);
 
-    List<Prediction> getPredictionHistoryByPredictor(UtilizationKey utilizationKey, DateTime start, DateTime end, int forecastDistanceInMinutes);
+    List<Prediction> getPredictionHistoryByPredictor(Long predictorId, DateTime start, DateTime end, int forecastDistanceInMinutes);
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
@@ -105,7 +105,7 @@ public class PredictionService {
             List<Prediction> predictions = predictor.predict(state, new UtilizationHistoryImpl(utilizationRepository, state.utilizationKey));
             // TODO: should we set state.latestUtilization here so that all predictors don't need to remember do it? or will some predictors use different logic for it, for example if they process only part of the updates?
             // TODO: save to prediction log
-            predictionRepository.updatePredictions(toPredictionBatch(state, predictions));
+            predictionRepository.updatePredictions(toPredictionBatch(state, predictions), predictorId);
             predictorRepository.save(state);
         });
     }

--- a/application/src/main/resources/db/common/V13_1__prediction_history_predictor_id.sql
+++ b/application/src/main/resources/db/common/V13_1__prediction_history_predictor_id.sql
@@ -1,0 +1,34 @@
+ALTER TABLE facility_prediction_history RENAME TO facility_prediction_history_old;
+
+CREATE TABLE facility_prediction_history (
+  predictor_id                 BIGINT    NOT NULL,
+  ts                           TIMESTAMP NOT NULL,
+  forecast_distance_in_minutes INT       NOT NULL,
+  spaces_available             INT       NOT NULL,
+
+  PRIMARY KEY (predictor_id, forecast_distance_in_minutes, ts),
+
+  CONSTRAINT facility_prediction_history_predictor_id_fk FOREIGN KEY (predictor_id)
+  REFERENCES predictor (id)
+);
+
+-- NOTE: This script relies on the fact that there was only one predictor in use
+-- at the time of writing. It should not cause problems, since there are no environments
+-- with multiple predictors
+INSERT INTO facility_prediction_history (
+  predictor_id,
+  ts,
+  forecast_distance_in_minutes,
+  spaces_available
+)
+  SELECT
+    p.id,
+    old.ts,
+    old.forecast_distance_in_minutes,
+    old.spaces_available
+  FROM predictor p, facility_prediction_history_old old
+  WHERE p.capacity_type = old.capacity_type
+        AND p.facility_id = old.facility_id
+        AND p.usage = old.usage;
+
+DROP TABLE facility_prediction_history_old;


### PR DESCRIPTION
Replaces `UtilizationKey` with `predictorId` in `facility_prediction_history`