### PR TITLE
LIIP-249: Don't drop or rename the old prediction history table

### DIFF
--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QCapacityType.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QCapacityType.java
@@ -1,19 +1,15 @@
 package fi.hsl.parkandride.back.sql;
 
-import static com.mysema.query.types.PathMetadataFactory.*;
-
-import com.mysema.query.types.path.*;
-
-import com.mysema.query.types.PathMetadata;
-import javax.annotation.Generated;
-import com.mysema.query.types.Path;
-
 import com.mysema.query.sql.ColumnMetadata;
+import com.mysema.query.sql.spatial.RelationalPathSpatial;
+import com.mysema.query.types.Path;
+import com.mysema.query.types.PathMetadata;
+import com.mysema.query.types.path.EnumPath;
+
+import javax.annotation.Generated;
 import java.sql.Types;
 
-import com.mysema.query.sql.spatial.RelationalPathSpatial;
-
-import com.mysema.query.spatial.path.*;
+import static com.mysema.query.types.PathMetadataFactory.forVariable;
 
 
 
@@ -38,6 +34,8 @@ public class QCapacityType extends RelationalPathSpatial<QCapacityType> {
     public final com.mysema.query.sql.ForeignKey<QFacilityPrediction> _facilityPredictionCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
 
     public final com.mysema.query.sql.ForeignKey<QPricing> _pricingCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
+
+    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
 
     public final com.mysema.query.sql.ForeignKey<QFacilityUtilization> _facilityUtilizationCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
 

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
@@ -123,6 +123,8 @@ public class QFacility extends RelationalPathSpatial<QFacility> {
 
     public final com.mysema.query.sql.ForeignKey<QUnavailableCapacity> _unavailableCapacityFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
+    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
+
     public final com.mysema.query.sql.ForeignKey<QFacilityPrediction> _facilityPredictionFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
     public final com.mysema.query.sql.ForeignKey<QFacilityPaymentMethod> _facilityPaymentMethodFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityPredictionHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityPredictionHistory.java
@@ -6,6 +6,7 @@ import com.mysema.query.types.Path;
 import com.mysema.query.types.PathMetadata;
 import com.mysema.query.types.path.DateTimePath;
 import com.mysema.query.types.path.NumberPath;
+import com.mysema.query.types.path.StringPath;
 
 import javax.annotation.Generated;
 import java.sql.Types;
@@ -24,17 +25,25 @@ public class QFacilityPredictionHistory extends RelationalPathSpatial<QFacilityP
 
     public static final QFacilityPredictionHistory facilityPredictionHistory = new QFacilityPredictionHistory("FACILITY_PREDICTION_HISTORY");
 
-    public final NumberPath<Integer> forecastDistanceInMinutes = createNumber("forecastDistanceInMinutes", Integer.class);
+    public final StringPath capacityType = createString("capacityType");
 
-    public final NumberPath<Long> predictorId = createNumber("predictorId", Long.class);
+    public final NumberPath<Long> facilityId = createNumber("facilityId", Long.class);
+
+    public final NumberPath<Integer> forecastDistanceInMinutes = createNumber("forecastDistanceInMinutes", Integer.class);
 
     public final NumberPath<Integer> spacesAvailable = createNumber("spacesAvailable", Integer.class);
 
     public final DateTimePath<org.joda.time.DateTime> ts = createDateTime("ts", org.joda.time.DateTime.class);
 
-    public final com.mysema.query.sql.PrimaryKey<QFacilityPredictionHistory> constraint34b = createPrimaryKey(forecastDistanceInMinutes, predictorId, ts);
+    public final StringPath usage = createString("usage");
 
-    public final com.mysema.query.sql.ForeignKey<QPredictor> facilityPredictionHistoryPredictorIdFk = createForeignKey(predictorId, "ID");
+    public final com.mysema.query.sql.PrimaryKey<QFacilityPredictionHistory> constraint34 = createPrimaryKey(capacityType, facilityId, forecastDistanceInMinutes, ts, usage);
+
+    public final com.mysema.query.sql.ForeignKey<QUsage> facilityPredictionHistoryUsageFk = createForeignKey(usage, "NAME");
+
+    public final com.mysema.query.sql.ForeignKey<QCapacityType> facilityPredictionHistoryCapacityTypeFk = createForeignKey(capacityType, "NAME");
+
+    public final com.mysema.query.sql.ForeignKey<QFacility> facilityPredictionHistoryFacilityIdFk = createForeignKey(facilityId, "ID");
 
     public QFacilityPredictionHistory(String variable) {
         super(QFacilityPredictionHistory.class, forVariable(variable), "PUBLIC", "FACILITY_PREDICTION_HISTORY");
@@ -57,10 +66,12 @@ public class QFacilityPredictionHistory extends RelationalPathSpatial<QFacilityP
     }
 
     public void addMetadata() {
-        addMetadata(forecastDistanceInMinutes, ColumnMetadata.named("FORECAST_DISTANCE_IN_MINUTES").withIndex(3).ofType(Types.INTEGER).withSize(10).notNull());
-        addMetadata(predictorId, ColumnMetadata.named("PREDICTOR_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
-        addMetadata(spacesAvailable, ColumnMetadata.named("SPACES_AVAILABLE").withIndex(4).ofType(Types.INTEGER).withSize(10).notNull());
-        addMetadata(ts, ColumnMetadata.named("TS").withIndex(2).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
+        addMetadata(capacityType, ColumnMetadata.named("CAPACITY_TYPE").withIndex(2).ofType(Types.VARCHAR).withSize(64).notNull());
+        addMetadata(facilityId, ColumnMetadata.named("FACILITY_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(forecastDistanceInMinutes, ColumnMetadata.named("FORECAST_DISTANCE_IN_MINUTES").withIndex(5).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(spacesAvailable, ColumnMetadata.named("SPACES_AVAILABLE").withIndex(6).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(ts, ColumnMetadata.named("TS").withIndex(4).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
+        addMetadata(usage, ColumnMetadata.named("USAGE").withIndex(3).ofType(Types.VARCHAR).withSize(64).notNull());
     }
 
 }

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityPredictionHistoryNew.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityPredictionHistoryNew.java
@@ -1,0 +1,70 @@
+package fi.hsl.parkandride.back.sql;
+
+import static com.mysema.query.types.PathMetadataFactory.*;
+
+import com.mysema.query.types.path.*;
+
+import com.mysema.query.types.PathMetadata;
+import javax.annotation.Generated;
+import com.mysema.query.types.Path;
+
+import com.mysema.query.sql.ColumnMetadata;
+import java.sql.Types;
+
+import com.mysema.query.sql.spatial.RelationalPathSpatial;
+
+import com.mysema.query.spatial.path.*;
+
+
+
+/**
+ * QFacilityPredictionHistoryNew is a Querydsl query type for QFacilityPredictionHistoryNew
+ */
+@Generated("com.mysema.query.sql.codegen.MetaDataSerializer")
+public class QFacilityPredictionHistoryNew extends RelationalPathSpatial<QFacilityPredictionHistoryNew> {
+
+    private static final long serialVersionUID = 1558434025;
+
+    public static final QFacilityPredictionHistoryNew facilityPredictionHistoryNew = new QFacilityPredictionHistoryNew("FACILITY_PREDICTION_HISTORY_NEW");
+
+    public final NumberPath<Integer> forecastDistanceInMinutes = createNumber("forecastDistanceInMinutes", Integer.class);
+
+    public final NumberPath<Long> predictorId = createNumber("predictorId", Long.class);
+
+    public final NumberPath<Integer> spacesAvailable = createNumber("spacesAvailable", Integer.class);
+
+    public final DateTimePath<org.joda.time.DateTime> ts = createDateTime("ts", org.joda.time.DateTime.class);
+
+    public final com.mysema.query.sql.PrimaryKey<QFacilityPredictionHistoryNew> constraint2e = createPrimaryKey(forecastDistanceInMinutes, predictorId, ts);
+
+    public final com.mysema.query.sql.ForeignKey<QPredictor> facilityPredictionHistoryPredictorIdFk = createForeignKey(predictorId, "ID");
+
+    public QFacilityPredictionHistoryNew(String variable) {
+        super(QFacilityPredictionHistoryNew.class, forVariable(variable), "PUBLIC", "FACILITY_PREDICTION_HISTORY_NEW");
+        addMetadata();
+    }
+
+    public QFacilityPredictionHistoryNew(String variable, String schema, String table) {
+        super(QFacilityPredictionHistoryNew.class, forVariable(variable), schema, table);
+        addMetadata();
+    }
+
+    public QFacilityPredictionHistoryNew(Path<? extends QFacilityPredictionHistoryNew> path) {
+        super(path.getType(), path.getMetadata(), "PUBLIC", "FACILITY_PREDICTION_HISTORY_NEW");
+        addMetadata();
+    }
+
+    public QFacilityPredictionHistoryNew(PathMetadata<?> metadata) {
+        super(QFacilityPredictionHistoryNew.class, metadata, "PUBLIC", "FACILITY_PREDICTION_HISTORY_NEW");
+        addMetadata();
+    }
+
+    public void addMetadata() {
+        addMetadata(forecastDistanceInMinutes, ColumnMetadata.named("FORECAST_DISTANCE_IN_MINUTES").withIndex(3).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(predictorId, ColumnMetadata.named("PREDICTOR_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(spacesAvailable, ColumnMetadata.named("SPACES_AVAILABLE").withIndex(4).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(ts, ColumnMetadata.named("TS").withIndex(2).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
+    }
+
+}
+

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QPredictor.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QPredictor.java
@@ -51,7 +51,7 @@ public class QPredictor extends RelationalPathSpatial<QPredictor> {
 
     public final com.mysema.query.sql.ForeignKey<QUsage> predictorUsageFk = createForeignKey(usage, "NAME");
 
-    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryPredictorIdFk = createInvForeignKey(id, "PREDICTOR_ID");
+    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistoryNew> _facilityPredictionHistoryPredictorIdFk = createInvForeignKey(id, "PREDICTOR_ID");
 
     public QPredictor(String variable) {
         super(QPredictor.class, forVariable(variable), "PUBLIC", "PREDICTOR");

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QUsage.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QUsage.java
@@ -1,19 +1,15 @@
 package fi.hsl.parkandride.back.sql;
 
-import static com.mysema.query.types.PathMetadataFactory.*;
-
-import com.mysema.query.types.path.*;
-
-import com.mysema.query.types.PathMetadata;
-import javax.annotation.Generated;
-import com.mysema.query.types.Path;
-
 import com.mysema.query.sql.ColumnMetadata;
+import com.mysema.query.sql.spatial.RelationalPathSpatial;
+import com.mysema.query.types.Path;
+import com.mysema.query.types.PathMetadata;
+import com.mysema.query.types.path.StringPath;
+
+import javax.annotation.Generated;
 import java.sql.Types;
 
-import com.mysema.query.sql.spatial.RelationalPathSpatial;
-
-import com.mysema.query.spatial.path.*;
+import static com.mysema.query.types.PathMetadataFactory.forVariable;
 
 
 
@@ -36,6 +32,8 @@ public class QUsage extends RelationalPathSpatial<QUsage> {
     public final com.mysema.query.sql.ForeignKey<QPricing> _pricingUsageFk = createInvForeignKey(name, "USAGE");
 
     public final com.mysema.query.sql.ForeignKey<QFacilityUtilization> _facilityUtilizationUsageFk = createInvForeignKey(name, "USAGE");
+
+    public final com.mysema.query.sql.ForeignKey<QFacilityPredictionHistory> _facilityPredictionHistoryUsageFk = createInvForeignKey(name, "USAGE");
 
     public final com.mysema.query.sql.ForeignKey<QUnavailableCapacity> _unavailableCapacityUsageFk = createInvForeignKey(name, "USAGE");
 

--- a/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
@@ -13,7 +13,7 @@ import com.mysema.query.types.Projections;
 import com.mysema.query.types.expr.BooleanExpression;
 import fi.hsl.parkandride.back.TimeUtil;
 import fi.hsl.parkandride.back.sql.QFacilityPrediction;
-import fi.hsl.parkandride.back.sql.QFacilityPredictionHistory;
+import fi.hsl.parkandride.back.sql.QFacilityPredictionHistoryNew;
 import fi.hsl.parkandride.core.back.PredictionRepository;
 import fi.hsl.parkandride.core.domain.UtilizationKey;
 import fi.hsl.parkandride.core.domain.prediction.Prediction;
@@ -39,7 +39,7 @@ import static java.util.stream.Collectors.toList;
 public class PredictionDao implements PredictionRepository {
 
     private static final QFacilityPrediction qPrediction = QFacilityPrediction.facilityPrediction;
-    private static final QFacilityPredictionHistory qPredictionHistory = QFacilityPredictionHistory.facilityPredictionHistory;
+    private static final QFacilityPredictionHistoryNew qPredictionHistory = QFacilityPredictionHistoryNew.facilityPredictionHistoryNew;
     private static final Map<String, Path<Integer>> spacesAvailableColumnsByHHmm = Collections.unmodifiableMap(
             Stream.of(qPrediction.all())
                     .filter(p -> p.getMetadata().getName().startsWith("spacesAvailableAt"))

--- a/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
+++ b/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
@@ -114,6 +114,7 @@ public class DevHelper {
         delete(
                 QFacilityPrediction.facilityPrediction,
                 QFacilityPredictionHistory.facilityPredictionHistory,
+                QFacilityPredictionHistoryNew.facilityPredictionHistoryNew,
                 QPredictor.predictor,
                 QFacilityUtilization.facilityUtilization,
                 QFacilityService.facilityService,

--- a/application/src/main/resources/db/common/V13_1__prediction_history_predictor_id.sql
+++ b/application/src/main/resources/db/common/V13_1__prediction_history_predictor_id.sql
@@ -1,6 +1,4 @@
-ALTER TABLE facility_prediction_history RENAME TO facility_prediction_history_old;
-
-CREATE TABLE facility_prediction_history (
+CREATE TABLE facility_prediction_history_new (
   predictor_id                 BIGINT    NOT NULL,
   ts                           TIMESTAMP NOT NULL,
   forecast_distance_in_minutes INT       NOT NULL,
@@ -15,7 +13,7 @@ CREATE TABLE facility_prediction_history (
 -- NOTE: This script relies on the fact that there was only one predictor in use
 -- at the time of writing. It should not cause problems, since there are no environments
 -- with multiple predictors
-INSERT INTO facility_prediction_history (
+INSERT INTO facility_prediction_history_new (
   predictor_id,
   ts,
   forecast_distance_in_minutes,
@@ -26,9 +24,7 @@ INSERT INTO facility_prediction_history (
     old.ts,
     old.forecast_distance_in_minutes,
     old.spaces_available
-  FROM predictor p, facility_prediction_history_old old
+  FROM predictor p, facility_prediction_history old
   WHERE p.capacity_type = old.capacity_type
         AND p.facility_id = old.facility_id
         AND p.usage = old.usage;
-
-DROP TABLE facility_prediction_history_old;


### PR DESCRIPTION
Dropping prediction history caused dead lock when deploying to test
environment. Solution was to keep the original history table and create
a new history table side by side with the old one.

NOTE: The old history table can be removed in future releases when it is not
in use anymore.

BREAKING CHANGES:
This commit modifies an existing db migration script (V13_1) and is incompatible
with versions including this script.