### PR TITLE
Minor fixes for reporting functionality

### DIFF
--- a/application/src/main/frontend/src/app/reports/reports.js
+++ b/application/src/main/frontend/src/app/reports/reports.js
@@ -60,9 +60,9 @@
         //
         // UTILS
         //
-        var date = new Date();
+        $scope.currentDate = new Date();
         function to_date(daynumber) {
-            return new Date(date.getFullYear(), date.getMonth(), daynumber,0,0,0);
+            return new Date($scope.currentDate.getFullYear(), $scope.currentDate.getMonth(), daynumber,0,0,0);
         }
         function date_toArray(date) {
             return [date.getDate(), date.getMonth()+1, date.getFullYear()];
@@ -75,7 +75,7 @@
         $scope.reportType = 'FacilityUsage';
         $scope.report = {
             startDate: to_date(1),
-            endDate: to_date(date.getDate()),
+            endDate: to_date($scope.currentDate.getDate()),
             interval: 60,
             capacityTypes: ['CAR'],
             regions: [],
@@ -89,6 +89,20 @@
                 var userOperatorId = user.operatorId;
                 $scope.report.operators = [userOperatorId];
                 $scope.fixedOperator = _.find($scope.allOperators, 'id', userOperatorId);
+            }
+        });
+
+        //
+        // DATES
+        //
+        $scope.$watch('report.startDate', function(newStartDate) {
+            if (newStartDate > $scope.report.endDate) {
+                $scope.report.endDate = newStartDate;
+            }
+        });
+        $scope.$watch('report.endDate', function(newEndDate) {
+            if (newEndDate < $scope.report.startDate) {
+                $scope.report.startDate = newEndDate;
             }
         });
 

--- a/application/src/main/frontend/src/app/reports/reports.tpl.html
+++ b/application/src/main/frontend/src/app/reports/reports.tpl.html
@@ -51,16 +51,16 @@
                        is-open="startDateOpen" ng-click="startDateOpen = true"
                        name="startDate"
                        class="form-control dateInput wdStartDate"
+                       max-date="currentDate"
                        ng-model="report.startDate"
-                       max-date="report.endDate"
                        ng-required="reportType != 'HubsAndFacilities'"/>
                 -
                 <input date-input datepicker-popup show-errors readonly
                        is-open="endDateOpen" ng-click="endDateOpen = true"
                        name="endDate"
                        class="form-control dateInput wdEndDate"
+                       max-date="currentDate"
                        ng-model="report.endDate"
-                       min-date="report.startDate"
                        ng-required="reportType != 'HubsAndFacilities'"/>
             </div>
         </div>

--- a/application/src/main/frontend/src/assets/translations-fi.json
+++ b/application/src/main/frontend/src/assets/translations-fi.json
@@ -684,7 +684,7 @@
         "placeholder": {
             "operator": "Kaikki operaattorit valittuna",
             "usage": "Kaikki käyttötavat valittuna",
-            "capacity": "Henkilöauto",
+            "capacity": "Kaikki ajoneuvotyypit valittuna",
             "region": "Kaikki kunnat valittuna",
             "hub": "Kaikki alueet valittuna",
             "facility": "Kaikki pysäköintipaikat valittuna"

--- a/application/src/main/frontend/src/common/directives/dateInput.js
+++ b/application/src/main/frontend/src/common/directives/dateInput.js
@@ -12,10 +12,9 @@
 
     m.config(function(datepickerConfig, datepickerPopupConfig, dateInputConfig) {
         _.extend(datepickerConfig, {
-            //focusOnOpen: true,
-            startingDay: 1, // Monday
-            minMode: 'day',
-            maxMode: 'day'
+            startingDay: 1,
+            yearRange: 5,
+            minDate: new Date(2010, 0, 1, 0, 0, 0)
         });
 
         _.extend(datepickerPopupConfig, {

--- a/application/src/main/java/fi/hsl/parkandride/core/util/ArgumentValidator.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/util/ArgumentValidator.java
@@ -18,6 +18,7 @@ import static fi.hsl.parkandride.core.util.Predicates.*;
 import static java.util.stream.Collectors.toList;
 
 public class ArgumentValidator<T> {
+    private static final String UNKNOWN_TYPE = "Unknown";
     private final T obj;
     private final Set<PredicateWithMessage<T>> predicates;
 
@@ -27,7 +28,7 @@ public class ArgumentValidator<T> {
     }
 
     public static <T> Builder<T> validate(T arg) {
-        return new Builder(arg);
+        return validate(arg, UNKNOWN_TYPE);
     }
 
     public static <T> Builder<T> validate(T arg, String type) {
@@ -71,14 +72,10 @@ public class ArgumentValidator<T> {
 
         private final T obj;
         private final Set<PredicateWithMessage<T>> predicates = new HashSet<>();
-        private String type = "Unknown";
-
-        public Builder(T obj) {
-            this.obj = obj;
-        }
+        private final String type;
 
         public Builder(T obj, String type) {
-            this(obj);
+            this.obj = obj;
             this.type = type;
         }
 

--- a/application/src/test/java/fi/hsl/parkandride/back/Dummies.java
+++ b/application/src/test/java/fi/hsl/parkandride/back/Dummies.java
@@ -111,7 +111,7 @@ public class Dummies {
 
     private static final AtomicInteger seq = new AtomicInteger(0);
 
-    private int uniqueNumber() {
-        return seq.incrementAndGet();
+    private String uniqueNumber() {
+        return String.format("%04d", seq.incrementAndGet());
     }
 }

--- a/application/src/test/java/fi/hsl/parkandride/itest/ReportingITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/ReportingITest.java
@@ -20,7 +20,6 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -320,8 +319,6 @@ public class ReportingITest extends AbstractIntegrationTest {
                 .doesNotContain(operator2.name.fi);
     }
 
-    // TODO: Unsure: should a hub display a grand total or per-operator rows
-    @Ignore("Unsure: should a hub display a grand total or per-operator rows")
     @Test
     public void report_MaxUtilization_asAdmin() {
         // Record mock usage data
@@ -333,9 +330,11 @@ public class ReportingITest extends AbstractIntegrationTest {
         // If this succeeds, the response was a valid excel file
         final Workbook workbook = readWorkbookFrom(whenPostingToReportUrl);
 
-        // Both operators are displayed
+
+        // Both operators are displayed with joined name
         assertThat(getDataFromColumn(workbook.getSheetAt(0), 2))
-                .contains("Operaattori", operator1.name.fi, operator2.name.fi);
+                .hasSize(4) // header + rows for working days, Sat, and Sun
+                .containsOnly("Operaattori", String.join(", ", operator1.name.fi, operator2.name.fi));
     }
 
     private void addMockMaxUtilizations(Facility f, User apiUser) {


### PR DESCRIPTION
1. Show all operators separated with commas in max utilization report
2. Correct placeholder text for capacity type filter