### PR TITLE
LIIP-260: Prediction table layout

### DIFF
--- a/application/src/main/frontend/src/app/facilities/facilityView.tpl.html
+++ b/application/src/main/frontend/src/app/facilities/facilityView.tpl.html
@@ -106,7 +106,7 @@
 		</div>
 		<div class="row">
 			<div class="column first-column">
-				<predictions-table predictions="viewCtrl.predictions" facility="viewCtrl.facility"></predictions-table>
+				<predictions-table utilization="viewCtrl.utilization" predictions="viewCtrl.predictions" facility="viewCtrl.facility"></predictions-table>
 			</div>
 		</div>
 	</div>

--- a/application/src/main/frontend/src/app/facilities/predictionsTable.tpl.html
+++ b/application/src/main/frontend/src/app/facilities/predictionsTable.tpl.html
@@ -5,12 +5,8 @@
 			<th id="facilities-view-pricing-capacityType" translate="facilities.pricing.capacityType.title"></th>
 			<th id="facilities-view-pricing-usage" translate="facilities.pricing.usage.title"></th>
 			<th id="facilities-utilization-capacity-build" translate="facilities.capacity.built"></th>
-			<th translate="facilities.capacity.availableNow"></th>
-			<th>5 min</th>
-			<th>10 min</th>
-			<th>15 min</th>
-			<th>30 min</th>
-			<th>60 min</th>
+			<th translate="facilities.capacity.current"></th>
+			<th ng-repeat="tm in predictionTimes" ng-bind="tm | date:'HH:mm'"></th>
 		</tr>
 		</thead>
 		<tbody>
@@ -21,12 +17,8 @@
 			</td>
 			<td ng-bind="'usages.' + row.usage + '.label' | translate" class="wdUsage"></td>
 			<td ng-bind="row.capacity"></td>
-			<td ng-bind="row.predictions[0]"></td>
-			<td ng-bind="row.predictions[5]"></td>
-			<td ng-bind="row.predictions[10]"></td>
-			<td ng-bind="row.predictions[15]"></td>
-			<td ng-bind="row.predictions[30]"></td>
-			<td ng-bind="row.predictions[60]"></td>
+			<td ng-bind="row.utilization.spacesAvailable" title="{{row.utilization.timestamp | date: 'HH:mm'}}"></td>
+			<td ng-repeat="tm in predictionTimes" ng-bind="row.predictions[tm]"></td>
 		</tr>
 		</tbody>
 	</table>

--- a/application/src/main/frontend/src/assets/translations-fi.json
+++ b/application/src/main/frontend/src/assets/translations-fi.json
@@ -419,7 +419,7 @@
             "available": "Paikkoja vapaana",
             "availableAndForecast": "Vapaana nyt ja ennustetiedot vapaiden paikkojen määrälle on haettu {{loadedDate | date:'HH:mm'}}. Jos haluat viimeisimmät tiedot, päivitä sivu.",
             "unavailable": "Tilapäisesti poissa käytöstä",
-            "availableNow": "Vapaana nyt"
+            "current": "Viimeisin tieto"
         },
         "builtCapacity": {
             "label": "Rakennettu kapasiteetti",

--- a/application/src/main/frontend/src/common/services/FacilityResource.js
+++ b/application/src/main/frontend/src/common/services/FacilityResource.js
@@ -79,8 +79,13 @@
             });
         };
 
+        api.getUtilization = function(id) {
+            return $http.get('api/v1/facilities/' + id + '/utilization')
+                .then(function(response) { return response.data; });
+        };
+
         api.getPredictions = function(id, after) {
-            return $http.get("api/v1/facilities/" + id + "/prediction", {
+            return $http.get('api/v1/facilities/' + id + '/prediction', {
                 params: {
                     after: after
                 }

--- a/application/src/main/java/fi/hsl/parkandride/dev/DevController.java
+++ b/application/src/main/java/fi/hsl/parkandride/dev/DevController.java
@@ -24,10 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.Resource;
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Spliterator;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -139,8 +136,9 @@ public class DevController {
     @TransactionalWrite
     public ResponseEntity<Void> generateUtilizationData(@NotNull @PathVariable(FACILITY_ID) Long facilityId) {
         final Facility facility = facilityRepository.getFacility(facilityId);
-        
+
         // Generate dummy usage for the last month
+        final Random random = new Random();
         final List<Utilization> utilizations = StreamSupport.stream(
                 spliteratorUnknownSize(new DateTimeIterator(DateTime.now().minusMonths(1), DateTime.now(), Minutes.minutes(5)), Spliterator.ORDERED), false)
                 .flatMap(ts -> Stream.of(CAR, DISABLED, ELECTRIC_CAR)
@@ -156,7 +154,7 @@ public class DevController {
                         .map(utilizationKey -> newUtilization(
                                 utilizationKey,
                                 facility.builtCapacity.get(utilizationKey.capacityType),
-                                ts
+                                ts.minusSeconds(random.nextInt(180)) // Randomness to prevent timestamps for different capacity types being equal
                         )))
                         .collect(toList());
         utilizationRepository.insertUtilizations(utilizations);


### PR DESCRIPTION
Changes the layout of the prediction table. Instead of showing relative times in the heading (5min, 10min, etc.), the table now displays the absolute times for the predictions, e.g., 9:05, 9:10, etc.

Furthermore, the spaces available column data is fetched from the `/utilization` endpoint to get the latest actual utilization rate.

Changes the forecast distances to 0, 10, 20, 30, and 60 minutes.