### PR TITLE
LIIP-263: Save status and capacity history for facilities

### DIFF
--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QCapacityType.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QCapacityType.java
@@ -41,6 +41,8 @@ public class QCapacityType extends RelationalPathSpatial<QCapacityType> {
 
     public final com.querydsl.sql.ForeignKey<QFacilityUtilization> _facilityUtilizationCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
 
+    public final com.querydsl.sql.ForeignKey<QUnavailableCapacityHistory> _unavailableCapacityHistoryCapacityTypeFk = createInvForeignKey(name, "CAPACITY_TYPE");
+
     public QCapacityType(String variable) {
         super(QCapacityType.class, forVariable(variable), "PUBLIC", "CAPACITY_TYPE");
         addMetadata();

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
@@ -123,6 +123,8 @@ public class QFacility extends RelationalPathSpatial<QFacility> {
 
     public final com.querydsl.sql.ForeignKey<QUnavailableCapacity> _unavailableCapacityFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
+    public final com.querydsl.sql.ForeignKey<QFacilityStatusHistory> _statusHistoryFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
+
     public final com.querydsl.sql.ForeignKey<QFacilityPrediction> _facilityPredictionFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
     public final com.querydsl.sql.ForeignKey<QFacilityPaymentMethod> _facilityPaymentMethodFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacility.java
@@ -123,6 +123,8 @@ public class QFacility extends RelationalPathSpatial<QFacility> {
 
     public final com.querydsl.sql.ForeignKey<QUnavailableCapacity> _unavailableCapacityFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
+    public final com.querydsl.sql.ForeignKey<QFacilityCapacityHistory> _capacityHistoryFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
+
     public final com.querydsl.sql.ForeignKey<QFacilityStatusHistory> _statusHistoryFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");
 
     public final com.querydsl.sql.ForeignKey<QFacilityPrediction> _facilityPredictionFacilityIdFk = createInvForeignKey(id, "FACILITY_ID");

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityCapacityHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityCapacityHistory.java
@@ -1,0 +1,88 @@
+package fi.hsl.parkandride.back.sql;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+
+import com.querydsl.sql.ColumnMetadata;
+import java.sql.Types;
+
+import com.querydsl.sql.spatial.RelationalPathSpatial;
+
+import com.querydsl.spatial.*;
+
+
+
+/**
+ * QFacilityCapacityHistory is a Querydsl query type for QFacilityCapacityHistory
+ */
+@Generated("com.querydsl.sql.codegen.MetaDataSerializer")
+public class QFacilityCapacityHistory extends RelationalPathSpatial<QFacilityCapacityHistory> {
+
+    private static final long serialVersionUID = 1636246316;
+
+    public static final QFacilityCapacityHistory facilityCapacityHistory = new QFacilityCapacityHistory("FACILITY_CAPACITY_HISTORY");
+
+    public final NumberPath<Integer> capacityBicycle = createNumber("capacityBicycle", Integer.class);
+
+    public final NumberPath<Integer> capacityBicycleSecureSpace = createNumber("capacityBicycleSecureSpace", Integer.class);
+
+    public final NumberPath<Integer> capacityCar = createNumber("capacityCar", Integer.class);
+
+    public final NumberPath<Integer> capacityDisabled = createNumber("capacityDisabled", Integer.class);
+
+    public final NumberPath<Integer> capacityElectricCar = createNumber("capacityElectricCar", Integer.class);
+
+    public final NumberPath<Integer> capacityMotorcycle = createNumber("capacityMotorcycle", Integer.class);
+
+    public final DateTimePath<org.joda.time.DateTime> endTs = createDateTime("endTs", org.joda.time.DateTime.class);
+
+    public final NumberPath<Long> facilityId = createNumber("facilityId", Long.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<org.joda.time.DateTime> startTs = createDateTime("startTs", org.joda.time.DateTime.class);
+
+    public final com.querydsl.sql.PrimaryKey<QFacilityCapacityHistory> constraint8e = createPrimaryKey(id);
+
+    public final com.querydsl.sql.ForeignKey<QFacility> capacityHistoryFacilityIdFk = createForeignKey(facilityId, "ID");
+
+    public QFacilityCapacityHistory(String variable) {
+        super(QFacilityCapacityHistory.class, forVariable(variable), "PUBLIC", "FACILITY_CAPACITY_HISTORY");
+        addMetadata();
+    }
+
+    public QFacilityCapacityHistory(String variable, String schema, String table) {
+        super(QFacilityCapacityHistory.class, forVariable(variable), schema, table);
+        addMetadata();
+    }
+
+    public QFacilityCapacityHistory(Path<? extends QFacilityCapacityHistory> path) {
+        super(path.getType(), path.getMetadata(), "PUBLIC", "FACILITY_CAPACITY_HISTORY");
+        addMetadata();
+    }
+
+    public QFacilityCapacityHistory(PathMetadata metadata) {
+        super(QFacilityCapacityHistory.class, metadata, "PUBLIC", "FACILITY_CAPACITY_HISTORY");
+        addMetadata();
+    }
+
+    public void addMetadata() {
+        addMetadata(capacityBicycle, ColumnMetadata.named("CAPACITY_BICYCLE").withIndex(9).ofType(Types.INTEGER).withSize(10));
+        addMetadata(capacityBicycleSecureSpace, ColumnMetadata.named("CAPACITY_BICYCLE_SECURE_SPACE").withIndex(10).ofType(Types.INTEGER).withSize(10));
+        addMetadata(capacityCar, ColumnMetadata.named("CAPACITY_CAR").withIndex(5).ofType(Types.INTEGER).withSize(10));
+        addMetadata(capacityDisabled, ColumnMetadata.named("CAPACITY_DISABLED").withIndex(6).ofType(Types.INTEGER).withSize(10));
+        addMetadata(capacityElectricCar, ColumnMetadata.named("CAPACITY_ELECTRIC_CAR").withIndex(7).ofType(Types.INTEGER).withSize(10));
+        addMetadata(capacityMotorcycle, ColumnMetadata.named("CAPACITY_MOTORCYCLE").withIndex(8).ofType(Types.INTEGER).withSize(10));
+        addMetadata(endTs, ColumnMetadata.named("END_TS").withIndex(4).ofType(Types.TIMESTAMP).withSize(23).withDigits(10));
+        addMetadata(facilityId, ColumnMetadata.named("FACILITY_ID").withIndex(2).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(startTs, ColumnMetadata.named("START_TS").withIndex(3).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
+    }
+
+}
+

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityCapacityHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityCapacityHistory.java
@@ -51,6 +51,8 @@ public class QFacilityCapacityHistory extends RelationalPathSpatial<QFacilityCap
 
     public final com.querydsl.sql.ForeignKey<QFacility> capacityHistoryFacilityIdFk = createForeignKey(facilityId, "ID");
 
+    public final com.querydsl.sql.ForeignKey<QUnavailableCapacityHistory> _unavailableCapacityHistoryIdFk = createInvForeignKey(id, "CAPACITY_HISTORY_ID");
+
     public QFacilityCapacityHistory(String variable) {
         super(QFacilityCapacityHistory.class, forVariable(variable), "PUBLIC", "FACILITY_CAPACITY_HISTORY");
         addMetadata();

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityStatusHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityStatusHistory.java
@@ -1,18 +1,19 @@
 package fi.hsl.parkandride.back.sql;
 
-import com.querydsl.core.types.Path;
-import com.querydsl.core.types.PathMetadata;
-import com.querydsl.core.types.dsl.DateTimePath;
-import com.querydsl.core.types.dsl.EnumPath;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.core.types.dsl.StringPath;
-import com.querydsl.sql.ColumnMetadata;
-import com.querydsl.sql.spatial.RelationalPathSpatial;
+import static com.querydsl.core.types.PathMetadataFactory.*;
 
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
 import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+
+import com.querydsl.sql.ColumnMetadata;
 import java.sql.Types;
 
-import static com.querydsl.core.types.PathMetadataFactory.forVariable;
+import com.querydsl.sql.spatial.RelationalPathSpatial;
+
+import com.querydsl.spatial.*;
 
 
 

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityStatusHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QFacilityStatusHistory.java
@@ -1,0 +1,81 @@
+package fi.hsl.parkandride.back.sql;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.EnumPath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.sql.ColumnMetadata;
+import com.querydsl.sql.spatial.RelationalPathSpatial;
+
+import javax.annotation.Generated;
+import java.sql.Types;
+
+import static com.querydsl.core.types.PathMetadataFactory.forVariable;
+
+
+
+/**
+ * QFacilityStatusHistory is a Querydsl query type for QFacilityStatusHistory
+ */
+@Generated("com.querydsl.sql.codegen.MetaDataSerializer")
+public class QFacilityStatusHistory extends RelationalPathSpatial<QFacilityStatusHistory> {
+
+    private static final long serialVersionUID = 1932287348;
+
+    public static final QFacilityStatusHistory facilityStatusHistory = new QFacilityStatusHistory("FACILITY_STATUS_HISTORY");
+
+    public final DateTimePath<org.joda.time.DateTime> endTs = createDateTime("endTs", org.joda.time.DateTime.class);
+
+    public final NumberPath<Long> facilityId = createNumber("facilityId", Long.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<org.joda.time.DateTime> startTs = createDateTime("startTs", org.joda.time.DateTime.class);
+
+    public final EnumPath<fi.hsl.parkandride.core.domain.FacilityStatus> status = createEnum("status", fi.hsl.parkandride.core.domain.FacilityStatus.class);
+
+    public final StringPath statusDescriptionEn = createString("statusDescriptionEn");
+
+    public final StringPath statusDescriptionFi = createString("statusDescriptionFi");
+
+    public final StringPath statusDescriptionSv = createString("statusDescriptionSv");
+
+    public final com.querydsl.sql.PrimaryKey<QFacilityStatusHistory> constraint8c = createPrimaryKey(id);
+
+    public final com.querydsl.sql.ForeignKey<QFacility> statusHistoryFacilityIdFk = createForeignKey(facilityId, "ID");
+
+    public QFacilityStatusHistory(String variable) {
+        super(QFacilityStatusHistory.class, forVariable(variable), "PUBLIC", "FACILITY_STATUS_HISTORY");
+        addMetadata();
+    }
+
+    public QFacilityStatusHistory(String variable, String schema, String table) {
+        super(QFacilityStatusHistory.class, forVariable(variable), schema, table);
+        addMetadata();
+    }
+
+    public QFacilityStatusHistory(Path<? extends QFacilityStatusHistory> path) {
+        super(path.getType(), path.getMetadata(), "PUBLIC", "FACILITY_STATUS_HISTORY");
+        addMetadata();
+    }
+
+    public QFacilityStatusHistory(PathMetadata metadata) {
+        super(QFacilityStatusHistory.class, metadata, "PUBLIC", "FACILITY_STATUS_HISTORY");
+        addMetadata();
+    }
+
+    public void addMetadata() {
+        addMetadata(endTs, ColumnMetadata.named("END_TS").withIndex(5).ofType(Types.TIMESTAMP).withSize(23).withDigits(10));
+        addMetadata(facilityId, ColumnMetadata.named("FACILITY_ID").withIndex(2).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(startTs, ColumnMetadata.named("START_TS").withIndex(4).ofType(Types.TIMESTAMP).withSize(23).withDigits(10).notNull());
+        addMetadata(status, ColumnMetadata.named("STATUS").withIndex(3).ofType(Types.VARCHAR).withSize(64).notNull());
+        addMetadata(statusDescriptionEn, ColumnMetadata.named("STATUS_DESCRIPTION_EN").withIndex(8).ofType(Types.VARCHAR).withSize(255));
+        addMetadata(statusDescriptionFi, ColumnMetadata.named("STATUS_DESCRIPTION_FI").withIndex(6).ofType(Types.VARCHAR).withSize(255));
+        addMetadata(statusDescriptionSv, ColumnMetadata.named("STATUS_DESCRIPTION_SV").withIndex(7).ofType(Types.VARCHAR).withSize(255));
+    }
+
+}
+

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QUnavailableCapacityHistory.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QUnavailableCapacityHistory.java
@@ -1,0 +1,74 @@
+package fi.hsl.parkandride.back.sql;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+
+import com.querydsl.sql.ColumnMetadata;
+import java.sql.Types;
+
+import com.querydsl.sql.spatial.RelationalPathSpatial;
+
+import com.querydsl.spatial.*;
+
+
+
+/**
+ * QUnavailableCapacityHistory is a Querydsl query type for QUnavailableCapacityHistory
+ */
+@Generated("com.querydsl.sql.codegen.MetaDataSerializer")
+public class QUnavailableCapacityHistory extends RelationalPathSpatial<QUnavailableCapacityHistory> {
+
+    private static final long serialVersionUID = 1491933717;
+
+    public static final QUnavailableCapacityHistory unavailableCapacityHistory = new QUnavailableCapacityHistory("UNAVAILABLE_CAPACITY_HISTORY");
+
+    public final NumberPath<Integer> capacity = createNumber("capacity", Integer.class);
+
+    public final NumberPath<Long> capacityHistoryId = createNumber("capacityHistoryId", Long.class);
+
+    public final EnumPath<fi.hsl.parkandride.core.domain.CapacityType> capacityType = createEnum("capacityType", fi.hsl.parkandride.core.domain.CapacityType.class);
+
+    public final EnumPath<fi.hsl.parkandride.core.domain.Usage> usage = createEnum("usage", fi.hsl.parkandride.core.domain.Usage.class);
+
+    public final com.querydsl.sql.PrimaryKey<QUnavailableCapacityHistory> constraint5d = createPrimaryKey(capacityHistoryId, capacityType, usage);
+
+    public final com.querydsl.sql.ForeignKey<QFacilityCapacityHistory> unavailableCapacityHistoryIdFk = createForeignKey(capacityHistoryId, "ID");
+
+    public final com.querydsl.sql.ForeignKey<QUsage> unavailableCapacityHistoryUsageFk = createForeignKey(usage, "NAME");
+
+    public final com.querydsl.sql.ForeignKey<QCapacityType> unavailableCapacityHistoryCapacityTypeFk = createForeignKey(capacityType, "NAME");
+
+    public QUnavailableCapacityHistory(String variable) {
+        super(QUnavailableCapacityHistory.class, forVariable(variable), "PUBLIC", "UNAVAILABLE_CAPACITY_HISTORY");
+        addMetadata();
+    }
+
+    public QUnavailableCapacityHistory(String variable, String schema, String table) {
+        super(QUnavailableCapacityHistory.class, forVariable(variable), schema, table);
+        addMetadata();
+    }
+
+    public QUnavailableCapacityHistory(Path<? extends QUnavailableCapacityHistory> path) {
+        super(path.getType(), path.getMetadata(), "PUBLIC", "UNAVAILABLE_CAPACITY_HISTORY");
+        addMetadata();
+    }
+
+    public QUnavailableCapacityHistory(PathMetadata metadata) {
+        super(QUnavailableCapacityHistory.class, metadata, "PUBLIC", "UNAVAILABLE_CAPACITY_HISTORY");
+        addMetadata();
+    }
+
+    public void addMetadata() {
+        addMetadata(capacity, ColumnMetadata.named("CAPACITY").withIndex(4).ofType(Types.INTEGER).withSize(10).notNull());
+        addMetadata(capacityHistoryId, ColumnMetadata.named("CAPACITY_HISTORY_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        addMetadata(capacityType, ColumnMetadata.named("CAPACITY_TYPE").withIndex(2).ofType(Types.VARCHAR).withSize(64).notNull());
+        addMetadata(usage, ColumnMetadata.named("USAGE").withIndex(3).ofType(Types.VARCHAR).withSize(64).notNull());
+    }
+
+}
+

--- a/application/src/generated/java/fi/hsl/parkandride/back/sql/QUsage.java
+++ b/application/src/generated/java/fi/hsl/parkandride/back/sql/QUsage.java
@@ -33,6 +33,8 @@ public class QUsage extends RelationalPathSpatial<QUsage> {
 
     public final com.querydsl.sql.ForeignKey<QFacilityPrediction> _facilityPredictionUsageFk = createInvForeignKey(name, "USAGE");
 
+    public final com.querydsl.sql.ForeignKey<QUnavailableCapacityHistory> _unavailableCapacityHistoryUsageFk = createInvForeignKey(name, "USAGE");
+
     public final com.querydsl.sql.ForeignKey<QPricing> _pricingUsageFk = createInvForeignKey(name, "USAGE");
 
     public final com.querydsl.sql.ForeignKey<QFacilityUtilization> _facilityUtilizationUsageFk = createInvForeignKey(name, "USAGE");

--- a/application/src/main/java/fi/hsl/parkandride/Application.java
+++ b/application/src/main/java/fi/hsl/parkandride/Application.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.system.ApplicationPidFileWriter;
-import org.springframework.boot.actuate.system.ApplicationPidListener;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;

--- a/application/src/main/java/fi/hsl/parkandride/back/FacilityHistoryDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/FacilityHistoryDao.java
@@ -1,0 +1,253 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.back;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.dml.StoreClause;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.MappingProjection;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.sql.SQLExpressions;
+import com.querydsl.sql.dml.SQLInsertClause;
+import com.querydsl.sql.postgresql.PostgreSQLQueryFactory;
+import fi.hsl.parkandride.back.sql.QFacilityCapacityHistory;
+import fi.hsl.parkandride.back.sql.QFacilityStatusHistory;
+import fi.hsl.parkandride.back.sql.QUnavailableCapacityHistory;
+import fi.hsl.parkandride.core.back.FacilityHistoryRepository;
+import fi.hsl.parkandride.core.domain.*;
+import fi.hsl.parkandride.core.service.TransactionalRead;
+import fi.hsl.parkandride.core.service.TransactionalWrite;
+import org.joda.time.DateTime;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static com.querydsl.core.types.Projections.constructor;
+import static com.querydsl.sql.SQLExpressions.select;
+import static fi.hsl.parkandride.core.domain.CapacityType.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+public class FacilityHistoryDao implements FacilityHistoryRepository {
+
+    public static final String STATUS_HISTORY_ID_SEQ = "facility_status_history_seq";
+    public static final String CAPACITY_HISTORY_ID_SEQ = "facility_capacity_history_seq";
+
+    private static final QFacilityStatusHistory qFacilityStatusHistory = QFacilityStatusHistory.facilityStatusHistory;
+    private static final QFacilityCapacityHistory qFacilityCapacityHistory = QFacilityCapacityHistory.facilityCapacityHistory;
+    private static final QUnavailableCapacityHistory qUnavailableCapacityHistory = QUnavailableCapacityHistory.unavailableCapacityHistory;
+    private static final MappingProjection<UnavailableCapacity> unavailableCapacityHistoryMapping = new MappingProjection<UnavailableCapacity>(UnavailableCapacity.class, qUnavailableCapacityHistory.all()) {
+        @Override
+        protected UnavailableCapacity map(Tuple row) {
+            final UnavailableCapacity uc = new UnavailableCapacity();
+            uc.capacityType = row.get(qUnavailableCapacityHistory.capacityType);
+            uc.usage = row.get(qUnavailableCapacityHistory.usage);
+            uc.capacity = row.get(qUnavailableCapacityHistory.capacity);
+            return uc;
+        }
+    };
+
+    private static final Expression<Long> nextStatusHistoryId = SQLExpressions.nextval(STATUS_HISTORY_ID_SEQ);
+    private static final Expression<Long> nextCapacityHistoryId = SQLExpressions.nextval(CAPACITY_HISTORY_ID_SEQ);
+    private static final MultilingualStringMapping statusHistoryDescriptionMapping = new MultilingualStringMapping(
+            qFacilityStatusHistory.statusDescriptionFi,
+            qFacilityStatusHistory.statusDescriptionSv,
+            qFacilityStatusHistory.statusDescriptionEn
+    );
+
+    private final PostgreSQLQueryFactory queryFactory;
+
+    public FacilityHistoryDao(PostgreSQLQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    private static void populateCapacity(NumberPath<Integer> path, Integer value, StoreClause store) {
+        if (value == null || value < 1) {
+            store.setNull(path);
+        } else {
+            store.set(path, value);
+        }
+    }
+
+    private static void mapCapacity(Map<CapacityType, Integer> capacities, CapacityType type, Integer capacity) {
+        if (capacity != null && capacity > 0) {
+            capacities.put(type, capacity);
+        }
+    }
+
+    @Override
+    @TransactionalWrite
+    public void updateCapacityHistory(DateTime currentDate, long facilityId, Map<CapacityType, Integer> builtCapacity, List<UnavailableCapacity> unavailableCapacities) {
+        setEndDateForPreviousCapacityHistoryEntry(facilityId, currentDate);
+        final long historyEntryId = insertNewCapacityHistoryEntry(facilityId, currentDate, builtCapacity);
+        insertUnavailableCapacitiesHistory(historyEntryId, unavailableCapacities);
+    }
+
+    private void insertUnavailableCapacitiesHistory(long historyEntryId, List<UnavailableCapacity> unavailableCapacities) {
+        if (unavailableCapacities.isEmpty()) {
+            return;
+        }
+        final SQLInsertClause insert = queryFactory.insert(qUnavailableCapacityHistory);
+        unavailableCapacities.forEach(uc -> {
+            insert.set(qUnavailableCapacityHistory.capacityHistoryId, historyEntryId)
+                    .set(qUnavailableCapacityHistory.capacityType, uc.capacityType)
+                    .set(qUnavailableCapacityHistory.usage, uc.usage)
+                    .set(qUnavailableCapacityHistory.capacity, uc.capacity);
+            insert.addBatch();
+        });
+        insert.execute();
+    }
+
+    @Override
+    @TransactionalWrite
+    public void updateStatusHistory(DateTime currentDate, long facilityId, FacilityStatus newStatus, MultilingualString statusDescription) {
+        setEndDateForPreviousStateHistoryEntry(facilityId, currentDate);
+        insertNewStatusHistoryEntry(facilityId, currentDate, newStatus, statusDescription);
+    }
+
+    private long insertNewStatusHistoryEntry(long facilityId, DateTime currentDate, FacilityStatus newStatus, MultilingualString statusDescription) {
+        final SQLInsertClause insert = queryFactory.insert(qFacilityStatusHistory);
+        statusHistoryDescriptionMapping.populate(statusDescription, insert);
+        return insert
+                .set(qFacilityStatusHistory.id, select(nextStatusHistoryId))
+                .set(qFacilityStatusHistory.facilityId, facilityId)
+                .set(qFacilityStatusHistory.status, newStatus)
+                .set(qFacilityStatusHistory.startTs, currentDate)
+                .execute();
+    }
+
+    private long insertNewCapacityHistoryEntry(long facilityId, DateTime currentDate, Map<CapacityType, Integer> builtCapacity) {
+        final Long historyEntryId = queryFactory.query().select(nextCapacityHistoryId).fetchOne();
+        final SQLInsertClause insert = queryFactory.insert(qFacilityCapacityHistory);
+        populateCapacity(qFacilityCapacityHistory.capacityCar, builtCapacity.get(CAR), insert);
+        populateCapacity(qFacilityCapacityHistory.capacityDisabled, builtCapacity.get(DISABLED), insert);
+        populateCapacity(qFacilityCapacityHistory.capacityElectricCar, builtCapacity.get(ELECTRIC_CAR), insert);
+        populateCapacity(qFacilityCapacityHistory.capacityMotorcycle, builtCapacity.get(MOTORCYCLE), insert);
+        populateCapacity(qFacilityCapacityHistory.capacityBicycle, builtCapacity.get(BICYCLE), insert);
+        populateCapacity(qFacilityCapacityHistory.capacityBicycleSecureSpace, builtCapacity.get(BICYCLE_SECURE_SPACE), insert);
+        insert.set(qFacilityCapacityHistory.id, historyEntryId)
+                .set(qFacilityCapacityHistory.facilityId, facilityId)
+                .set(qFacilityCapacityHistory.startTs, currentDate)
+                .execute();
+        return historyEntryId;
+    }
+
+    private void setEndDateForPreviousStateHistoryEntry(long facilityId, DateTime currentDate) {
+        final Long lastHistoryEntryId = queryFactory.query().select(qFacilityStatusHistory.id)
+                .from(qFacilityStatusHistory)
+                .where(qFacilityStatusHistory.facilityId.eq(facilityId))
+                .orderBy(qFacilityStatusHistory.startTs.desc())
+                .fetchFirst();
+
+        if (lastHistoryEntryId != null) {
+            queryFactory.update(qFacilityStatusHistory)
+                    .set(qFacilityStatusHistory.endTs, currentDate)
+                    .where(qFacilityStatusHistory.id.eq(lastHistoryEntryId))
+                    .execute();
+        }
+    }
+
+    private void setEndDateForPreviousCapacityHistoryEntry(long facilityId, DateTime currentDate) {
+        final Long lastHistoryEntryId = queryFactory.query().select(qFacilityCapacityHistory.id)
+                .from(qFacilityCapacityHistory)
+                .where(qFacilityCapacityHistory.facilityId.eq(facilityId))
+                .orderBy(qFacilityCapacityHistory.startTs.desc())
+                .fetchFirst();
+
+        if (lastHistoryEntryId != null) {
+            queryFactory.update(qFacilityCapacityHistory)
+                    .set(qFacilityCapacityHistory.endTs, currentDate)
+                    .where(qFacilityCapacityHistory.id.eq(lastHistoryEntryId))
+                    .execute();
+        }
+    }
+
+    @Override
+    @TransactionalRead
+    public List<FacilityStatusHistory> getStatusHistory(long facilityId) {
+        return queryFactory.query()
+                .select(constructor(
+                        FacilityStatusHistory.class,
+                        qFacilityStatusHistory.facilityId,
+                        qFacilityStatusHistory.startTs,
+                        qFacilityStatusHistory.endTs,
+                        qFacilityStatusHistory.status,
+                        statusHistoryDescriptionMapping
+                ))
+                .from(qFacilityStatusHistory)
+                .where(qFacilityStatusHistory.facilityId.eq(facilityId))
+                .orderBy(qFacilityStatusHistory.startTs.asc())
+                .fetch();
+    }
+
+    @Override
+    @TransactionalRead
+    public List<FacilityCapacityHistory> getCapacityHistory(long facilityId) {
+        final List<ExtendedCapacityHistory> capacityHistory = getCapacityHistoryWithoutUnavailableCapacities(facilityId);
+
+        final Set<Long> historyEntryIds = capacityHistory.stream().map(c -> c.id).collect(toSet());
+        final Map<Long, List<UnavailableCapacity>> unavailableCapacities = queryFactory
+                .from(qUnavailableCapacityHistory)
+                .where(qUnavailableCapacityHistory.capacityHistoryId.in(historyEntryIds))
+                .transform(groupBy(qUnavailableCapacityHistory.capacityHistoryId).as(list(unavailableCapacityHistoryMapping)));
+
+        return capacityHistory.stream()
+                .map(entry -> {
+                    entry.unavailableCapacities = unavailableCapacities.get(entry.id);
+                    return entry.strip();
+                })
+                .collect(toList());
+    }
+
+    private List<ExtendedCapacityHistory> getCapacityHistoryWithoutUnavailableCapacities(long facilityId) {
+        return queryFactory.query()
+                .select(constructor(
+                        ExtendedCapacityHistory.class,
+                        qFacilityCapacityHistory.id,
+                        qFacilityCapacityHistory.facilityId,
+                        qFacilityCapacityHistory.startTs,
+                        qFacilityCapacityHistory.endTs,
+                        new MappingProjection<Map<CapacityType, Integer>>(Map.class, qFacilityCapacityHistory.all()) {
+                            @Override
+                            protected Map<CapacityType, Integer> map(Tuple row) {
+                                final Map<CapacityType, Integer> map = new HashMap<>();
+                                mapCapacity(map, CAR, row.get(qFacilityCapacityHistory.capacityCar));
+                                mapCapacity(map, DISABLED, row.get(qFacilityCapacityHistory.capacityDisabled));
+                                mapCapacity(map, ELECTRIC_CAR, row.get(qFacilityCapacityHistory.capacityElectricCar));
+                                mapCapacity(map, MOTORCYCLE, row.get(qFacilityCapacityHistory.capacityMotorcycle));
+                                mapCapacity(map, BICYCLE, row.get(qFacilityCapacityHistory.capacityBicycle));
+                                mapCapacity(map, BICYCLE_SECURE_SPACE, row.get(qFacilityCapacityHistory.capacityBicycleSecureSpace));
+                                return map;
+                            }
+                        }
+                ))
+                .from(qFacilityCapacityHistory)
+                .where(qFacilityCapacityHistory.facilityId.eq(facilityId))
+                .orderBy(qFacilityCapacityHistory.startTs.asc())
+                .fetch();
+    }
+
+    public static class ExtendedCapacityHistory extends FacilityCapacityHistory {
+        public Long id;
+
+        public ExtendedCapacityHistory(Long id, Long facilityId, DateTime startDate, DateTime endDate, Map<CapacityType, Integer> builtCapacity) {
+            super(facilityId, startDate, endDate, builtCapacity);
+            this.id = id;
+        }
+
+        public FacilityCapacityHistory strip() {
+            return new FacilityCapacityHistory(
+                    facilityId,
+                    startDate,
+                    endDate,
+                    builtCapacity,
+                    unavailableCapacities
+            );
+        }
+    }
+}

--- a/application/src/main/java/fi/hsl/parkandride/config/CoreConfiguration.java
+++ b/application/src/main/java/fi/hsl/parkandride/config/CoreConfiguration.java
@@ -145,7 +145,12 @@ public class CoreConfiguration {
 
     @Bean
     public FacilityRepository facilityRepository() {
-        return new FacilityDao(queryFactory);
+        return new FacilityDao(queryFactory, facilityHistoryRepository());
+    }
+
+    @Bean
+    public FacilityHistoryRepository facilityHistoryRepository() {
+        return new FacilityHistoryDao(queryFactory);
     }
 
     @Bean

--- a/application/src/main/java/fi/hsl/parkandride/config/JdbcConfiguration.java
+++ b/application/src/main/java/fi/hsl/parkandride/config/JdbcConfiguration.java
@@ -131,6 +131,9 @@ public class JdbcConfiguration {
         conf.register("UNAVAILABLE_CAPACITY", "CAPACITY_TYPE", new EnumByNameType<>(CapacityType.class));
         conf.register("UNAVAILABLE_CAPACITY", "USAGE", new EnumByNameType<>(Usage.class));
 
+        conf.register("UNAVAILABLE_CAPACITY_HISTORY", "CAPACITY_TYPE", new EnumByNameType<>(CapacityType.class));
+        conf.register("UNAVAILABLE_CAPACITY_HISTORY", "USAGE", new EnumByNameType<>(Usage.class));
+
         conf.register("CAPACITY_TYPE", "NAME", new EnumByNameType<>(CapacityType.class));
 
         conf.register("CONTACT", "PHONE", new PhoneType());

--- a/application/src/main/java/fi/hsl/parkandride/config/JdbcConfiguration.java
+++ b/application/src/main/java/fi/hsl/parkandride/config/JdbcConfiguration.java
@@ -149,6 +149,8 @@ public class JdbcConfiguration {
 
         conf.register("FACILITY_SERVICE", "SERVICE", new EnumByNameType<>(Service.class));
 
+        conf.register("FACILITY_STATUS_HISTORY", "STATUS", new EnumByNameType<>(FacilityStatus.class));
+
         conf.register("FACILITY_PAYMENT_METHOD", "PAYMENT_METHOD", new EnumByNameType<>(PaymentMethod.class));
 
         conf.register("PREDICTOR", "CAPACITY_TYPE", new EnumByNameType<>(CapacityType.class));

--- a/application/src/main/java/fi/hsl/parkandride/core/back/FacilityHistoryRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/FacilityHistoryRepository.java
@@ -1,0 +1,41 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.back;
+
+import fi.hsl.parkandride.core.domain.*;
+import org.joda.time.DateTime;
+
+import java.util.List;
+import java.util.Map;
+
+public interface FacilityHistoryRepository {
+
+    /**
+     * Updates the capacity history for the given facility. Ends the previous history entry to given date if applicable.
+     * @param currentDate the end date for the previous entry and the start date for the entry to insert
+     * @param facilityId
+     * @param builtCapacity
+     * @param unavailableCapacities
+     */
+    void updateCapacityHistory(DateTime currentDate, long facilityId, Map<CapacityType, Integer> builtCapacity, List<UnavailableCapacity> unavailableCapacities);
+
+    /**
+     * Updates the status history for the given facility. Ends the previous history entry to given date if applicable.
+     * @param currentDate the end date for the previous entry and the start date for the entry to insert
+     * @param facilityId
+     * @param builtCapacity
+     * @param unavailableCapacities
+     */
+    void updateStatusHistory(DateTime currentDate, long facilityId, FacilityStatus newStatus, MultilingualString statusDescription);
+
+    /**
+     * Get the whole capacity history for the facility ordered by start date asc
+     */
+    List<FacilityCapacityHistory> getCapacityHistory(long facilityId);
+
+    /**
+     * Get the whole status history for the facility ordered by start date asc
+     */
+    List<FacilityStatusHistory> getStatusHistory(long facilityId);
+}

--- a/application/src/main/java/fi/hsl/parkandride/core/back/FacilityRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/FacilityRepository.java
@@ -5,9 +5,13 @@ package fi.hsl.parkandride.core.back;
 
 import fi.hsl.parkandride.core.domain.*;
 
+import java.util.List;
+
 public interface FacilityRepository {
 
     long insertFacility(Facility facility);
+
+    List<FacilityStatusHistory> getStatusHistory(long facilityId);
 
     void updateFacility(long facilityId, Facility facility);
 

--- a/application/src/main/java/fi/hsl/parkandride/core/back/FacilityRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/FacilityRepository.java
@@ -12,6 +12,7 @@ public interface FacilityRepository {
     long insertFacility(Facility facility);
 
     List<FacilityStatusHistory> getStatusHistory(long facilityId);
+    List<FacilityCapacityHistory> getCapacityHistory(long facilityId);
 
     void updateFacility(long facilityId, Facility facility);
 

--- a/application/src/main/java/fi/hsl/parkandride/core/back/FacilityRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/FacilityRepository.java
@@ -5,14 +5,9 @@ package fi.hsl.parkandride.core.back;
 
 import fi.hsl.parkandride.core.domain.*;
 
-import java.util.List;
-
 public interface FacilityRepository {
 
     long insertFacility(Facility facility);
-
-    List<FacilityStatusHistory> getStatusHistory(long facilityId);
-    List<FacilityCapacityHistory> getCapacityHistory(long facilityId);
 
     void updateFacility(long facilityId, Facility facility);
 

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityCapacityHistory.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityCapacityHistory.java
@@ -1,0 +1,68 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import fi.hsl.parkandride.core.domain.validation.MinElement;
+import fi.hsl.parkandride.core.domain.validation.NotNullElement;
+import org.joda.time.DateTime;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+public class FacilityCapacityHistory {
+    public Long facilityId;
+    public DateTime startDate;
+    public DateTime endDate;
+
+    @NotNullElement
+    @MinElement(1)
+    @NotNull
+    public Map<CapacityType, Integer> builtCapacity = newHashMap();
+
+    public FacilityCapacityHistory() {
+    }
+
+    public FacilityCapacityHistory(Long facilityId, DateTime startDate, DateTime endDate, Map<CapacityType, Integer> builtCapacity) {
+        this.facilityId = facilityId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.builtCapacity = builtCapacity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FacilityCapacityHistory)) {
+            return false;
+        }
+        FacilityCapacityHistory that = (FacilityCapacityHistory) o;
+        return Objects.equal(facilityId, that.facilityId) &&
+                Objects.equal(startDate, that.startDate) &&
+                Objects.equal(endDate, that.endDate) &&
+                Objects.equal(builtCapacity, that.builtCapacity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(facilityId, startDate, endDate, builtCapacity);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("facilityId", facilityId)
+                .add("startDate", startDate)
+                .add("endDate", endDate)
+                .add("builtCapacity", builtCapacity)
+                .toString();
+    }
+
+
+}

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityCapacityHistory.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityCapacityHistory.java
@@ -10,6 +10,7 @@ import fi.hsl.parkandride.core.domain.validation.NotNullElement;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -24,6 +25,8 @@ public class FacilityCapacityHistory {
     @NotNull
     public Map<CapacityType, Integer> builtCapacity = newHashMap();
 
+    public List<UnavailableCapacity> unavailableCapacities;
+
     public FacilityCapacityHistory() {
     }
 
@@ -32,6 +35,11 @@ public class FacilityCapacityHistory {
         this.startDate = startDate;
         this.endDate = endDate;
         this.builtCapacity = builtCapacity;
+    }
+
+    public FacilityCapacityHistory(Long facilityId, DateTime startDate, DateTime endDate, Map<CapacityType, Integer> builtCapacity, List<UnavailableCapacity> unavailableCapacities) {
+        this(facilityId, startDate, endDate, builtCapacity);
+        this.unavailableCapacities = unavailableCapacities;
     }
 
     @Override
@@ -46,12 +54,13 @@ public class FacilityCapacityHistory {
         return Objects.equal(facilityId, that.facilityId) &&
                 Objects.equal(startDate, that.startDate) &&
                 Objects.equal(endDate, that.endDate) &&
-                Objects.equal(builtCapacity, that.builtCapacity);
+                Objects.equal(builtCapacity, that.builtCapacity) &&
+                Objects.equal(unavailableCapacities, that.unavailableCapacities);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(facilityId, startDate, endDate, builtCapacity);
+        return Objects.hashCode(facilityId, startDate, endDate, builtCapacity, unavailableCapacities);
     }
 
     @Override
@@ -61,6 +70,7 @@ public class FacilityCapacityHistory {
                 .add("startDate", startDate)
                 .add("endDate", endDate)
                 .add("builtCapacity", builtCapacity)
+                .add("unavailableCapacities", unavailableCapacities)
                 .toString();
     }
 

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityStatusHistory.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityStatusHistory.java
@@ -1,0 +1,61 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import org.joda.time.DateTime;
+
+public class FacilityStatusHistory {
+    public Long facilityId;
+    public DateTime startDate;
+    public DateTime endDate;
+    public FacilityStatus status;
+    public MultilingualString statusDescription;
+
+    public FacilityStatusHistory() {
+    }
+
+    public FacilityStatusHistory(Long facilityId, DateTime startDate, DateTime endDate, FacilityStatus status, MultilingualString statusDescription) {
+        this.facilityId = facilityId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+        this.statusDescription = statusDescription;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FacilityStatusHistory)) {
+            return false;
+        }
+        FacilityStatusHistory that = (FacilityStatusHistory) o;
+        return Objects.equal(facilityId, that.facilityId) &&
+                Objects.equal(startDate, that.startDate) &&
+                Objects.equal(endDate, that.endDate) &&
+                Objects.equal(status, that.status) &&
+                Objects.equal(statusDescription, that.statusDescription);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(facilityId, startDate, endDate, status, statusDescription);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("facilityId", facilityId)
+                .add("startDate", startDate)
+                .add("endDate", endDate)
+                .add("status", status)
+                .add("statusDescription", statusDescription)
+                .toString();
+    }
+
+
+}

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/UnavailableCapacity.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/UnavailableCapacity.java
@@ -3,15 +3,14 @@
 
 package fi.hsl.parkandride.core.domain;
 
-import static java.util.Comparator.comparing;
-import static java.util.Comparator.naturalOrder;
-import static java.util.Comparator.nullsLast;
-
-import java.util.Comparator;
-import java.util.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.util.Comparator;
+import java.util.Objects;
+
+import static java.util.Comparator.*;
 
 public class UnavailableCapacity {
 
@@ -57,6 +56,16 @@ public class UnavailableCapacity {
             return false;
         }
     }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("capacityType", capacityType)
+                .add("usage", usage)
+                .add("capacity", capacity)
+                .toString();
+    }
+
 
     public CapacityType getCapacityType() {
         return capacityType;

--- a/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
+++ b/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
@@ -123,6 +123,7 @@ public class DevHelper {
                 QPort.port,
                 QUnavailableCapacity.unavailableCapacity,
                 QFacilityStatusHistory.facilityStatusHistory,
+                QUnavailableCapacityHistory.unavailableCapacityHistory,
                 QFacilityCapacityHistory.facilityCapacityHistory,
                 QFacility.facility);
         resetPredictorSequence();

--- a/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
+++ b/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
@@ -122,6 +122,7 @@ public class DevHelper {
                 QPricing.pricing,
                 QPort.port,
                 QUnavailableCapacity.unavailableCapacity,
+                QFacilityStatusHistory.facilityStatusHistory,
                 QFacility.facility);
         resetPredictorSequence();
         resetFacilitySequence();

--- a/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
+++ b/application/src/main/java/fi/hsl/parkandride/dev/DevHelper.java
@@ -123,6 +123,7 @@ public class DevHelper {
                 QPort.port,
                 QUnavailableCapacity.unavailableCapacity,
                 QFacilityStatusHistory.facilityStatusHistory,
+                QFacilityCapacityHistory.facilityCapacityHistory,
                 QFacility.facility);
         resetPredictorSequence();
         resetFacilitySequence();

--- a/application/src/main/resources/db/common/V16__facility_status_history.sql
+++ b/application/src/main/resources/db/common/V16__facility_status_history.sql
@@ -1,0 +1,22 @@
+CREATE TABLE facility_status_history (
+  id                    BIGINT      NOT NULL,
+  facility_id           BIGINT      NOT NULL,
+
+  status                VARCHAR(64) NOT NULL,
+
+  start_ts              TIMESTAMP   NOT NULL,
+  end_ts                TIMESTAMP, -- end date may be empty when still current
+
+  status_description_fi VARCHAR(255),
+  status_description_sv VARCHAR(255),
+  status_description_en VARCHAR(255),
+
+  PRIMARY KEY (id),
+
+  CONSTRAINT status_history_facility_id_fk FOREIGN KEY (facility_id)
+  REFERENCES facility (id)
+);
+CREATE SEQUENCE facility_status_history_seq INCREMENT BY 1 START WITH 1;
+CREATE INDEX facility_status_history_status_idx ON facility_status_history (status);
+CREATE INDEX facility_status_history_start_idx ON facility_status_history (start_ts);
+CREATE INDEX facility_status_history_end_idx ON facility_status_history (end_ts);

--- a/application/src/main/resources/db/common/V17__facility_capacity_history.sql
+++ b/application/src/main/resources/db/common/V17__facility_capacity_history.sql
@@ -1,0 +1,22 @@
+CREATE TABLE facility_capacity_history (
+  id                            BIGINT    NOT NULL,
+  facility_id                   BIGINT    NOT NULL,
+
+  start_ts                      TIMESTAMP NOT NULL,
+  end_ts                        TIMESTAMP, -- end date may be empty when still current
+
+  capacity_car                  INT,
+  capacity_disabled             INT,
+  capacity_electric_car         INT,
+  capacity_motorcycle           INT,
+  capacity_bicycle              INT,
+  capacity_bicycle_secure_space INT,
+
+  PRIMARY KEY (id),
+
+  CONSTRAINT capacity_history_facility_id_fk FOREIGN KEY (facility_id)
+  REFERENCES facility (id)
+);
+CREATE SEQUENCE facility_capacity_history_seq INCREMENT BY 1 START WITH 1;
+CREATE INDEX facility_capacity_history_start_idx ON facility_status_history (start_ts);
+CREATE INDEX facility_capacity_history_end_idx ON facility_status_history (end_ts);

--- a/application/src/main/resources/db/common/V18__facility_unavailable_capacity_history.sql
+++ b/application/src/main/resources/db/common/V18__facility_unavailable_capacity_history.sql
@@ -1,0 +1,17 @@
+CREATE TABLE unavailable_capacity_history (
+  capacity_history_id bigint not null,
+  capacity_type VARCHAR(64) NOT NULL,
+  usage         VARCHAR(64) NOT NULL,
+  capacity      INT         NOT NULL,
+
+  PRIMARY KEY (capacity_history_id, capacity_type, usage),
+
+  CONSTRAINT unavailable_capacity_history_id_fk FOREIGN KEY (capacity_history_id)
+  REFERENCES facility_capacity_history (id),
+
+  CONSTRAINT unavailable_capacity_history_usage_fk FOREIGN KEY (usage)
+  REFERENCES usage (name),
+
+  CONSTRAINT unavailable_capacity_history_capacity_type_fk FOREIGN KEY (capacity_type)
+  REFERENCES capacity_type (name)
+);

--- a/application/src/test/java/fi/hsl/parkandride/back/Dummies.java
+++ b/application/src/test/java/fi/hsl/parkandride/back/Dummies.java
@@ -53,12 +53,14 @@ public class Dummies {
         return facilityDao.insertFacility(facility);
     }
 
-    private Long createDummyOperator() {
+    @TransactionalWrite
+    public Long createDummyOperator() {
         Operator operator = new Operator("SMOOTH" + uniqueNumber());
         return operatorDao.insertOperator(operator);
     }
 
-    private Long createDummyContact() {
+    @TransactionalWrite
+    public Long createDummyContact() {
         Contact contact = new Contact();
         contact.name = new MultilingualString("TEST " + uniqueNumber());
         contact.email = "test@example.com";

--- a/application/src/test/java/fi/hsl/parkandride/back/FacilityHistoryDaoTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/back/FacilityHistoryDaoTest.java
@@ -1,0 +1,146 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.back;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import fi.hsl.parkandride.core.domain.*;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static fi.hsl.parkandride.core.domain.CapacityType.CAR;
+import static fi.hsl.parkandride.core.domain.CapacityType.ELECTRIC_CAR;
+import static fi.hsl.parkandride.core.domain.FacilityStatus.EXCEPTIONAL_SITUATION;
+import static fi.hsl.parkandride.core.domain.FacilityStatus.INACTIVE;
+import static fi.hsl.parkandride.core.domain.Usage.PARK_AND_RIDE;
+import static fi.hsl.parkandride.test.DateTimeTestUtils.withDate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FacilityHistoryDaoTest extends AbstractDaoTest {
+
+    @Inject
+    FacilityHistoryDao facilityHistoryDao;
+
+    @Inject
+    FacilityDao facilityDao;
+
+    @Inject
+    Dummies dummies;
+
+    private Facility facility;
+
+    @Before
+    public void initialize() {
+        final Long dummyOperator = dummies.createDummyOperator();
+        facility = FacilityDaoTest.createFacility(dummyOperator, new FacilityContacts(dummies.createDummyContact(), dummies.createDummyContact()));
+    }
+
+    @Test
+    public void facility_status_history_is_saved() {
+        final DateTime firstDate  = new DateTime().minusDays(10);
+        final DateTime secondDate = firstDate.plusDays(1);
+        final DateTime thirdDate  = firstDate.plusDays(2);
+        final DateTime fourthDate = firstDate.plusDays(3);
+
+        // First date
+        final long facilityId = withDate(firstDate, () -> {
+            long facId = facilityDao.insertFacility(facility);
+            assertThat(facilityHistoryDao.getStatusHistory(facId)).hasSize(1);
+            return facId;
+        });
+        final Facility fac = facilityDao.getFacility(facilityId);
+
+        // Second date
+        withDate(secondDate, () -> {
+            fac.status = FacilityStatus.INACTIVE;
+            facilityDao.updateFacility(facilityId, fac);
+            assertThat(facilityHistoryDao.getStatusHistory(facilityId)).hasSize(2);
+        });
+
+        // Third date
+        // This shouldn't create more entries since state did not change
+        withDate(thirdDate, () -> {
+            facilityDao.updateFacility(facilityId, fac);
+            assertThat(facilityHistoryDao.getStatusHistory(facilityId)).hasSize(2);
+        });
+
+        // Fourth date
+        // But this should since the description changed
+        final MultilingualString newStatus = new MultilingualString(FacilityDaoTest.STATUS_DESCRIPTION.fi);
+        newStatus.sv = "Inte i bruk";
+        withDate(fourthDate, () -> {
+            fac.statusDescription = newStatus;
+            facilityDao.updateFacility(facilityId, fac);
+        });
+
+        final List<FacilityStatusHistory> history = facilityHistoryDao.getStatusHistory(facilityId);
+        assertThat(history).containsExactly(
+                new FacilityStatusHistory(facilityId, firstDate, secondDate, EXCEPTIONAL_SITUATION, FacilityDaoTest.STATUS_DESCRIPTION),
+                new FacilityStatusHistory(facilityId, secondDate, fourthDate, INACTIVE, FacilityDaoTest.STATUS_DESCRIPTION),
+                new FacilityStatusHistory(facilityId, fourthDate, null, INACTIVE, newStatus)
+        );
+    }
+
+
+    @Test
+    public void facility_capacity_history_is_saved() {
+        final DateTime firstDate  = new DateTime().minusDays(10);
+        final DateTime secondDate = firstDate.plusDays(1);
+        final DateTime thirdDate  = firstDate.plusDays(2);
+        final DateTime fourthDate = firstDate.plusDays(3);
+
+        // First date
+        final long facilityId = withDate(firstDate, () -> {
+            facility.unavailableCapacities = newArrayList(new UnavailableCapacity(
+                    CAR, PARK_AND_RIDE, 1
+            ));
+            long facId = facilityDao.insertFacility(facility);
+            assertThat(facilityHistoryDao.getCapacityHistory(facId)).hasSize(1);
+            return facId;
+        });
+        final Facility fac = facilityDao.getFacility(facilityId);
+        final Map<CapacityType, Integer> original = ImmutableMap.copyOf(fac.builtCapacity);
+        final List<UnavailableCapacity> unavailable = ImmutableList.copyOf(fac.unavailableCapacities);
+
+        // Second date
+        // We change a value
+        final Map<CapacityType, Integer> second = withDate(secondDate, () -> {
+            fac.builtCapacity.put(CAR, 49);
+            facilityDao.updateFacility(facilityId, fac);
+            assertThat(facilityHistoryDao.getCapacityHistory(facilityId)).hasSize(2);
+            return ImmutableMap.copyOf(fac.builtCapacity);
+        });
+
+        // Third date
+        // Nothing saved, since nothing changes
+        withDate(thirdDate, () -> {
+            fac.status = INACTIVE;
+            facilityDao.updateFacility(facilityId, fac);
+            assertThat(facilityHistoryDao.getCapacityHistory(facilityId)).hasSize(2);
+        });
+
+        // Fourth date
+        // We add an entry to unavailable capacities
+        final List<UnavailableCapacity> modified = withDate(fourthDate, () -> {
+            fac.unavailableCapacities.add(new UnavailableCapacity(
+                    ELECTRIC_CAR, PARK_AND_RIDE, 5
+            ));
+            facilityDao.updateFacility(facilityId, fac);
+            return ImmutableList.copyOf(fac.unavailableCapacities);
+        });
+
+        final List<FacilityCapacityHistory> history = facilityHistoryDao.getCapacityHistory(facilityId);
+        assertThat(history).containsExactly(
+                new FacilityCapacityHistory(facilityId, firstDate, secondDate, original, unavailable),
+                new FacilityCapacityHistory(facilityId, secondDate, fourthDate, second, unavailable),
+                new FacilityCapacityHistory(facilityId, fourthDate, null, second, modified)
+        );
+    }
+}

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/FacilityStatusHistoryTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/FacilityStatusHistoryTest.java
@@ -1,0 +1,40 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static fi.hsl.parkandride.core.domain.FacilityStatus.INACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FacilityStatusHistoryTest {
+
+    private static final DateTime START = new DateTime().minusMonths(1);
+    private static final DateTime END = new DateTime();
+    private static final MultilingualString STATUS = new MultilingualString("status");
+
+    @Test
+    public void simpleEquals() {
+        final FacilityStatusHistory eka = new FacilityStatusHistory(123l, START, END, INACTIVE, STATUS);
+        final FacilityStatusHistory toka = new FacilityStatusHistory();
+        toka.facilityId = 123l;
+        toka.startDate = START;
+        toka.endDate = END;
+        toka.status = INACTIVE;
+        toka.statusDescription = STATUS;
+        assertThat(eka).isEqualTo(toka);
+    }
+
+    @Test
+    public void equalsHashCodeWork() {
+        EqualsVerifier.forClass(FacilityStatusHistory.class)
+                .allFieldsShouldBeUsed()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+
+}

--- a/application/src/test/java/fi/hsl/parkandride/test/DateTimeTestUtils.java
+++ b/application/src/test/java/fi/hsl/parkandride/test/DateTimeTestUtils.java
@@ -1,0 +1,27 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.test;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+
+import java.util.function.Supplier;
+
+public final class DateTimeTestUtils {
+    private DateTimeTestUtils() { /** prevent instantiation */}
+
+    public static <V> V withDate(DateTime date, Supplier<V> r) {
+        DateTimeUtils.setCurrentMillisFixed(date.getMillis());
+        final V v = r.get();
+        DateTimeUtils.setCurrentMillisSystem();
+        return v;
+    }
+
+    public static void withDate(DateTime date, Runnable r) {
+        withDate(date, () -> {
+            r.run();
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Saves capacity and status history for facilities when changed.

**Status history**
* A status history entry is inserted when a facility is created or updated and the status or status description changes
* The entry contains the full status description at the moment of update
* The entries have start and end timestamps, the end of the current entry being `null`
* Internally, this is stored in a single table `facility_status_history`
* Existing facilities get their first status history entry when their status changes

**Capacity history**
* A capacity hsitory entry is inserted when the built or unavailable capacity of a facility changes
* The entry contains both built and unavailable capacity present at the moment of update
* The entries have start and end timestamps, the end of the current entry being `null`
* Internally, this is stored in two tables `facility_capacity_history` and `unavailable_capacity_history`
* Existing facilities get their first capacity history entry when their capacity changes