### PR TITLE
LIIP-272: Add dev REST API to generate prediction history for facility

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/core/back/PredictionRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/PredictionRepository.java
@@ -6,6 +6,7 @@ package fi.hsl.parkandride.core.back;
 import fi.hsl.parkandride.core.domain.UtilizationKey;
 import fi.hsl.parkandride.core.domain.prediction.Prediction;
 import fi.hsl.parkandride.core.domain.prediction.PredictionBatch;
+import fi.hsl.parkandride.core.service.TransactionalWrite;
 import org.joda.time.DateTime;
 import org.joda.time.Hours;
 import org.joda.time.Minutes;
@@ -19,6 +20,8 @@ public interface PredictionRepository {
     Minutes PREDICTION_RESOLUTION = Minutes.minutes(5);
 
     void updatePredictions(PredictionBatch predictions, Long predictorId);
+
+    void updateOnlyPredictionHistory(PredictionBatch pb, Long predictorId);
 
     Optional<PredictionBatch> getPrediction(UtilizationKey utilizationKey, DateTime time);
 

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryList.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryList.java
@@ -1,0 +1,47 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain.prediction;
+
+import com.mysema.commons.lang.CloseableIterator;
+import com.mysema.commons.lang.IteratorAdapter;
+import fi.hsl.parkandride.core.back.UtilizationRepository;
+import fi.hsl.parkandride.core.domain.Utilization;
+import fi.hsl.parkandride.core.domain.UtilizationKey;
+import org.joda.time.DateTime;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
+
+public class UtilizationHistoryList implements UtilizationHistory {
+    private final List<Utilization> utilizationList;
+
+    public UtilizationHistoryList(List<Utilization> utilizationList) {
+        if (utilizationList == null || utilizationList.size() == 0)
+            throw new IllegalArgumentException("utilizationList must not be null or empty.");
+        this.utilizationList = utilizationList;
+    }
+
+    @Override
+    public Utilization getLatest() {
+        return utilizationList.stream().reduce(utilizationList.get(0), BinaryOperator.maxBy((a, b) -> a.timestamp.compareTo(b.timestamp)));
+    }
+
+    @Override
+    public List<Utilization> getRange(DateTime startInclusive, DateTime endInclusive) {
+        return utilizationList.stream()
+                .filter(utilization -> !utilization.timestamp.isBefore(startInclusive) && !utilization.timestamp.isAfter(endInclusive))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CloseableIterator<Utilization> getUpdatesSince(DateTime startExclusive) {
+        return new IteratorAdapter<Utilization>(
+                utilizationList.stream()
+                .filter(utilization -> utilization.timestamp.isAfter(startExclusive))
+                .iterator()
+        );
+    }
+}

--- a/application/src/main/java/fi/hsl/parkandride/front/UrlSchema.java
+++ b/application/src/main/java/fi/hsl/parkandride/front/UrlSchema.java
@@ -88,6 +88,7 @@ public final class UrlSchema {
     public static final String DEV_HUBS = DEV_API + "/hubs";
     public static final String DEV_UTILIZATION = DEV_FACILITIES + "/{" + FACILITY_ID + "}/utilization";
     public static final String DEV_PREDICTION = DEV_API + "/prediction";
+    public static final String DEV_PREDICTION_HISTORY = DEV_FACILITIES + "/{" + FACILITY_ID + "}/prediction_history";
 
     public static String urlEncode(String str) {
         try {


### PR DESCRIPTION
In addition to the dev REST API, modified PredictionDao to store only predictions for the following distances: 5, 10, 15, 20, 30, 45 minutes, and 1, 2, 4, 8, 12, 16, 20, 24 hours. That is, only 14 predictions are stored instead of 288 (every 5 minutes for 24 hours). In other words, this cuts down the storage requirement for prediction history by 95%.