### PR TITLE
LIIP-257: ignore utilizations without built capacity

### DIFF
--- a/application/src/test/java/fi/hsl/parkandride/itest/ReportingITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/ReportingITest.java
@@ -347,7 +347,10 @@ public class ReportingITest extends AbstractIntegrationTest {
         // If this succeeds, the response was a valid excel file
         // Both operators are displayed with joined name
         withWorkbook(whenPostingToReportUrl, workbook -> {
-            assertThat(getDataFromColumn(workbook.getSheetAt(0), 2))
+            final Sheet sheet = workbook.getSheetAt(0);
+            // Should not contain bicycle, even if when utilization is registered, since there is no built capacity
+            assertThat(getDataFromColumn(sheet, 4)).containsOnly("Ajoneuvotyyppi", "Henkilöauto");
+            assertThat(getDataFromColumn(sheet, 2))
                     .hasSize(4) // header + rows for working days, Sat, and Sun
                     .containsOnly("Operaattori", String.join(", ", operator1.name.fi, operator2.name.fi));
         });
@@ -363,7 +366,10 @@ public class ReportingITest extends AbstractIntegrationTest {
                 // 25/50 =  50%
                 utilize(CAR, capacity - (capacity / 2), baseDate.withDayOfWeek(SATURDAY), f),
                 // 10/50 =  20%
-                utilize(CAR, capacity - (capacity / 5), baseDate.withDayOfWeek(SUNDAY), f)
+                utilize(CAR, capacity - (capacity / 5), baseDate.withDayOfWeek(SUNDAY), f),
+
+                // BICYCLE_SECURE_SPACE does not exist in built capacity, should not fail
+                utilize(BICYCLE_SECURE_SPACE, 0, baseDate.withDayOfWeek(MONDAY), f)
         ), apiUser);
     }
 

--- a/application/src/test/java/fi/hsl/parkandride/itest/RequestLogITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/RequestLogITest.java
@@ -425,7 +425,7 @@ public class RequestLogITest extends AbstractIntegrationTest {
     }
 
 
-    private void printSheet(Sheet sheet) {
+    static void printSheet(Sheet sheet) {
         final DataFormatter dataFormatter = new DataFormatter();
         for (Row row : sheet) {
             for (Cell cell : row) {


### PR DESCRIPTION
[LIIP-257](https://hsl-liipi.atlassian.net/browse/LIIP-257): Fixes Max Utilization report failing silently when there were utilizations registered without corresponding built capacity for the facility. Report now shows only rows with built capacity