### PR TITLE
LIIP-270: relativize predictions

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/back/ListUtil.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/ListUtil.java
@@ -1,0 +1,34 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.back;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ListUtil {
+
+    public static <T> List<List<T>> transpose(List<List<T>> sources) {
+        List<Iterator<T>> iterators = sources.stream()
+                .map(List::iterator)
+                .collect(Collectors.toList());
+        List<List<T>> results = new ArrayList<>();
+        while (hasNexts(iterators)) {
+            results.add(nexts(iterators));
+        }
+        return results;
+    }
+
+    private static <T> boolean hasNexts(List<Iterator<T>> heads) {
+        return heads.stream().anyMatch(Iterator::hasNext);
+    }
+
+    private static <T> List<T> nexts(List<Iterator<T>> heads) {
+        return heads.stream()
+                .filter(Iterator::hasNext)
+                .map(Iterator::next)
+                .collect(Collectors.toList());
+    }
+}

--- a/application/src/main/java/fi/hsl/parkandride/config/CoreConfiguration.java
+++ b/application/src/main/java/fi/hsl/parkandride/config/CoreConfiguration.java
@@ -8,8 +8,8 @@ import fi.hsl.parkandride.back.*;
 import fi.hsl.parkandride.back.prediction.PredictionDao;
 import fi.hsl.parkandride.back.prediction.PredictorDao;
 import fi.hsl.parkandride.core.back.*;
-import fi.hsl.parkandride.core.domain.prediction.AverageOfPreviousWeeksPredictor;
 import fi.hsl.parkandride.core.domain.prediction.Predictor;
+import fi.hsl.parkandride.core.domain.prediction.RelativizedAverageOfPreviousWeeksPredictor;
 import fi.hsl.parkandride.core.service.*;
 import fi.hsl.parkandride.core.service.reporting.*;
 import org.jasypt.util.password.PasswordEncryptor;
@@ -180,7 +180,7 @@ public class CoreConfiguration {
 
     @Bean
     public Predictor[] predictors() {
-        return new Predictor[]{new AverageOfPreviousWeeksPredictor()};
+        return new Predictor[]{new RelativizedAverageOfPreviousWeeksPredictor()};
     }
 
     @Bean

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/AverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/AverageOfPreviousWeeksPredictor.java
@@ -3,6 +3,7 @@
 
 package fi.hsl.parkandride.core.domain.prediction;
 
+import fi.hsl.parkandride.back.ListUtil;
 import fi.hsl.parkandride.core.back.PredictionRepository;
 import fi.hsl.parkandride.core.domain.Utilization;
 import org.joda.time.DateTime;
@@ -42,7 +43,7 @@ public class AverageOfPreviousWeeksPredictor implements Predictor {
                 })
                 .collect(Collectors.toList());
 
-        List<List<Prediction>> groupedByTimeOfDay = transpose(groupedByWeek);
+        List<List<Prediction>> groupedByTimeOfDay = ListUtil.transpose(groupedByWeek);
 
         return groupedByTimeOfDay.stream()
                 .map(this::reduce)
@@ -61,27 +62,5 @@ public class AverageOfPreviousWeeksPredictor implements Predictor {
                 .average()
                 .getAsDouble());
         return new Prediction(timestamp, spacesAvailable);
-    }
-
-    private static <T> List<List<T>> transpose(List<List<T>> sources) {
-        List<Iterator<T>> iterators = sources.stream()
-                .map(List::iterator)
-                .collect(Collectors.toList());
-        List<List<T>> results = new ArrayList<>();
-        while (hasNexts(iterators)) {
-            results.add(nexts(iterators));
-        }
-        return results;
-    }
-
-    private static <T> boolean hasNexts(List<Iterator<T>> heads) {
-        return heads.stream().anyMatch(Iterator::hasNext);
-    }
-
-    private static <T> List<T> nexts(List<Iterator<T>> heads) {
-        return heads.stream()
-                .filter(Iterator::hasNext)
-                .map(Iterator::next)
-                .collect(Collectors.toList());
     }
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/AverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/AverageOfPreviousWeeksPredictor.java
@@ -10,9 +10,7 @@ import org.joda.time.Weeks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,8 +27,9 @@ public class AverageOfPreviousWeeksPredictor implements Predictor {
 
     @Override
     public List<Prediction> predict(PredictorState state, UtilizationHistory history) {
-        Utilization latest = history.getLatest();
-        DateTime now = state.latestUtilization = latest.timestamp;
+        Optional<Utilization> latest = history.getLatest();
+        if (!latest.isPresent()) return Collections.emptyList();
+        DateTime now = state.latestUtilization = latest.get().timestamp;
 
         List<List<Prediction>> groupedByWeek = Stream.of(Weeks.weeks(1), Weeks.weeks(2), Weeks.weeks(3))
                 .map(offset -> {

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
@@ -94,7 +94,8 @@ public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
                 .mapToDouble(u -> u.spacesAvailable)
                 .average()
                 .getAsDouble());
-        return new Prediction(timestamp, spacesAvailable + spacesAvailableCorrection);
+        final int predictedSpacesAvailable = Math.max(0, spacesAvailable + spacesAvailableCorrection);
+        return new Prediction(timestamp, predictedSpacesAvailable);
     }
 
     private static <T> List<List<T>> transpose(List<List<T>> sources) {

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
@@ -3,6 +3,7 @@
 
 package fi.hsl.parkandride.core.domain.prediction;
 
+import fi.hsl.parkandride.back.ListUtil;
 import fi.hsl.parkandride.core.back.PredictionRepository;
 import fi.hsl.parkandride.core.domain.Utilization;
 import org.joda.time.DateTime;
@@ -70,7 +71,7 @@ public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList());
 
-        List<List<Prediction>> groupedByTimeOfDay = transpose(groupedByWeek);
+        List<List<Prediction>> groupedByTimeOfDay = ListUtil.transpose(groupedByWeek);
 
         return groupedByTimeOfDay.stream()
                 .map(predictions -> reduce(predictions, latest.get().spacesAvailable, utilizationMultiplier))
@@ -96,27 +97,5 @@ public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
                 .getAsDouble());
         final int predictedSpacesAvailable = Math.max(0, spacesAvailable + spacesAvailableCorrection);
         return new Prediction(timestamp, predictedSpacesAvailable);
-    }
-
-    private static <T> List<List<T>> transpose(List<List<T>> sources) {
-        List<Iterator<T>> iterators = sources.stream()
-                .map(List::iterator)
-                .collect(Collectors.toList());
-        List<List<T>> results = new ArrayList<>();
-        while (hasNexts(iterators)) {
-            results.add(nexts(iterators));
-        }
-        return results;
-    }
-
-    private static <T> boolean hasNexts(List<Iterator<T>> heads) {
-        return heads.stream().anyMatch(Iterator::hasNext);
-    }
-
-    private static <T> List<T> nexts(List<Iterator<T>> heads) {
-        return heads.stream()
-                .filter(Iterator::hasNext)
-                .map(Iterator::next)
-                .collect(Collectors.toList());
     }
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
@@ -1,0 +1,90 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain.prediction;
+
+import fi.hsl.parkandride.core.back.PredictionRepository;
+import fi.hsl.parkandride.core.domain.Utilization;
+import org.joda.time.DateTime;
+import org.joda.time.ReadablePeriod;
+import org.joda.time.Weeks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
+
+    private static final Logger log = LoggerFactory.getLogger(RelativizedAverageOfPreviousWeeksPredictor.class);
+    private static final List<ReadablePeriod> LOOKBACK_PERIODS = Arrays.asList(Weeks.weeks(1), Weeks.weeks(2), Weeks.weeks(3));
+
+    public static final String TYPE = "relative-average-of-previous-weeks";
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public List<Prediction> predict(PredictorState state, UtilizationHistory history) {
+        Utilization latest = history.getLatest();
+        DateTime now = state.latestUtilization = latest.timestamp;
+
+        final UtilizationHistory inMemoryHistory = new UtilizationHistoryList(history.getRange(now.minusWeeks(3), now));
+
+        List<List<Prediction>> groupedByWeek =
+                LOOKBACK_PERIODS.stream()
+                .map(offset -> {
+                    DateTime start = now.minus(offset);
+                    DateTime end = start.plus(PredictionRepository.PREDICTION_WINDOW);
+                    List<Utilization> utilizations = inMemoryHistory.getRange(start, end);
+                    return utilizations.stream()
+                            .map(u -> new Prediction(u.timestamp.plus(offset), u.spacesAvailable))
+                            .collect(Collectors.toList());
+                })
+                .collect(Collectors.toList());
+
+        List<List<Prediction>> groupedByTimeOfDay = transpose(groupedByWeek);
+
+        return groupedByTimeOfDay.stream()
+                .map(this::reduce)
+                .collect(Collectors.toList());
+    }
+
+    private Prediction reduce(List<Prediction> predictions) {
+        DateTime timestamp = predictions.get(0).timestamp;
+        if (!predictions.stream()
+                .map(p -> p.timestamp)
+                .allMatch(timestamp::equals)) {
+            log.warn("Something went wrong. Not all predictions have the same timestamp: {}", predictions);
+        }
+        int spacesAvailable = (int) Math.round(predictions.stream()
+                .mapToInt(u -> u.spacesAvailable)
+                .average()
+                .getAsDouble());
+        return new Prediction(timestamp, spacesAvailable);
+    }
+
+    private static <T> List<List<T>> transpose(List<List<T>> sources) {
+        List<Iterator<T>> iterators = sources.stream()
+                .map(List::iterator)
+                .collect(Collectors.toList());
+        List<List<T>> results = new ArrayList<>();
+        while (hasNexts(iterators)) {
+            results.add(nexts(iterators));
+        }
+        return results;
+    }
+
+    private static <T> boolean hasNexts(List<Iterator<T>> heads) {
+        return heads.stream().anyMatch(Iterator::hasNext);
+    }
+
+    private static <T> List<T> nexts(List<Iterator<T>> heads) {
+        return heads.stream()
+                .filter(Iterator::hasNext)
+                .map(Iterator::next)
+                .collect(Collectors.toList());
+    }
+}

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
@@ -6,6 +6,7 @@ package fi.hsl.parkandride.core.domain.prediction;
 import fi.hsl.parkandride.core.back.PredictionRepository;
 import fi.hsl.parkandride.core.domain.Utilization;
 import org.joda.time.DateTime;
+import org.joda.time.Minutes;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.Weeks;
 import org.slf4j.Logger;
@@ -17,7 +18,9 @@ import java.util.stream.Collectors;
 public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
 
     private static final Logger log = LoggerFactory.getLogger(RelativizedAverageOfPreviousWeeksPredictor.class);
-    private static final List<ReadablePeriod> LOOKBACK_PERIODS = Arrays.asList(Weeks.weeks(1), Weeks.weeks(2), Weeks.weeks(3));
+
+    public static final List<ReadablePeriod> LOOKBACK_PERIODS = Arrays.asList(Weeks.weeks(1), Weeks.weeks(2), Weeks.weeks(3));
+    public static final Minutes LOOKBACK_MINUTES = Minutes.minutes(120);
 
     public static final String TYPE = "relative-average-of-previous-weeks";
 
@@ -29,53 +32,65 @@ public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
     @Override
     public List<Prediction> predict(PredictorState state, UtilizationHistory history) {
         Optional<Utilization> latest = history.getLatest();
-        if (!latest.isPresent()) return Collections.emptyList();
+        if (!latest.isPresent()) {
+            return Collections.emptyList();
+        }
         DateTime now = state.latestUtilization = latest.get().timestamp;
 
-        final UtilizationHistory inMemoryHistory = new UtilizationHistoryList(history.getRange(now.minusWeeks(3), now));
+        final UtilizationHistory inMemoryHistory = new UtilizationHistoryList(history.getRange(now.minusWeeks(3).minus(LOOKBACK_MINUTES), now));
+        final List<Utilization> recentUtilizations = inMemoryHistory.getRange(now.minus(LOOKBACK_MINUTES), now);
+        Double recentUtilizationArea = Math.max(1, calculateAreaAverageByDataPoints(recentUtilizations));
+        Double referenceUtilizationAreaAverage = Math.max(1,
+                LOOKBACK_PERIODS.stream()
+                        .map(offset -> now.minus(offset))
+                        .map(referenceTime -> inMemoryHistory.getRange(referenceTime.minus(LOOKBACK_MINUTES), referenceTime))
+                        .filter(utilizationList -> !utilizationList.isEmpty())
+                        .mapToDouble(utilizationList -> calculateAreaAverageByDataPoints(utilizationList))
+                        .average()
+                        .orElseGet(() -> recentUtilizationArea));
+        final Double utilizationMultiplier = Math.max(1, recentUtilizationArea / referenceUtilizationAreaAverage);
 
         List<List<Prediction>> groupedByWeek =
                 LOOKBACK_PERIODS.stream()
-                .map(offset -> {
-                    DateTime start = now.minus(offset);
-                    DateTime end = start.plus(PredictionRepository.PREDICTION_WINDOW);
-                    Optional<Utilization> utilizationAtReferenceTime = inMemoryHistory.getAt(start);
-                    if (!utilizationAtReferenceTime.isPresent()) {
-                        return null;
-                    }
+                        .map(offset -> {
+                            offset.toMutablePeriod().add(PredictionRepository.PREDICTION_WINDOW);
+                            DateTime start = now.minus(offset);
+                            DateTime end = start.plus(PredictionRepository.PREDICTION_WINDOW);
+                            Optional<Utilization> utilizationAtReferenceTime = inMemoryHistory.getAt(start);
+                            if (!utilizationAtReferenceTime.isPresent()) {
+                                return null;
+                            }
 
-                    Integer spacesAvailableAtReferenceTime = utilizationAtReferenceTime.get().spacesAvailable;
-                    List<Utilization> utilizations = inMemoryHistory.getRange(start, end);
-                    return utilizations.stream()
-                            .map(u -> new Prediction(u.timestamp.plus(offset), u.spacesAvailable - spacesAvailableAtReferenceTime))
-                            .collect(Collectors.toList());
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                            Integer spacesAvailableAtReferenceTime = utilizationAtReferenceTime.get().spacesAvailable;
+                            List<Utilization> utilizations = inMemoryHistory.getRange(start, end);
+                            return utilizations.stream()
+                                    .map(u -> new Prediction(u.timestamp.plus(offset), u.spacesAvailable - spacesAvailableAtReferenceTime))
+                                    .collect(Collectors.toList());
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
 
         List<List<Prediction>> groupedByTimeOfDay = transpose(groupedByWeek);
 
         return groupedByTimeOfDay.stream()
-                .map(predictions -> reduce(predictions, latest.get().spacesAvailable))
+                .map(predictions -> reduce(predictions, latest.get().spacesAvailable, utilizationMultiplier))
                 .collect(Collectors.toList());
     }
 
-    private OptionalDouble getHistoricUtilizationAt(UtilizationHistory inMemoryHistory, DateTime timestamp, List<ReadablePeriod> lookbackPeriods) {
-        return lookbackPeriods.stream()
-                .map(period -> inMemoryHistory.getAt(timestamp.minus(period)))
-                .filter(Optional::isPresent)
-                .mapToDouble(utilization -> utilization.get().spacesAvailable)
-                .average();
+    private double calculateAreaAverageByDataPoints(List<Utilization> utilizationList) {
+        int referenceSpaces = utilizationList.get(utilizationList.size() - 1).spacesAvailable;
+        return utilizationList.stream()
+                .mapToDouble(u -> Math.abs(u.spacesAvailable - referenceSpaces)).average().getAsDouble();
     }
 
-    private Prediction reduce(List<Prediction> predictions, int spacesAvailableCorrection) {
+    private Prediction reduce(List<Prediction> predictions, int spacesAvailableCorrection, double utilizationMultiplier) {
         DateTime timestamp = predictions.get(0).timestamp;
         if (!predictions.stream()
                 .map(p -> p.timestamp)
                 .allMatch(timestamp::equals)) {
             log.warn("Something went wrong. Not all predictions have the same timestamp: {}", predictions);
         }
-        int spacesAvailable = (int) Math.round(predictions.stream()
+        int spacesAvailable = (int) Math.round(utilizationMultiplier * predictions.stream()
                 .mapToDouble(u -> u.spacesAvailable)
                 .average()
                 .getAsDouble());

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistory.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistory.java
@@ -8,6 +8,7 @@ import fi.hsl.parkandride.core.domain.Utilization;
 import org.joda.time.DateTime;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UtilizationHistory {
 
@@ -16,4 +17,6 @@ public interface UtilizationHistory {
     List<Utilization> getRange(DateTime startInclusive, DateTime endInclusive);
 
     CloseableIterator<Utilization> getUpdatesSince(DateTime startExclusive);
+
+    Optional<Utilization> getAt(DateTime timestamp);
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistory.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistory.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface UtilizationHistory {
 
-    Utilization getLatest();
+    Optional<Utilization> getLatest();
 
     List<Utilization> getRange(DateTime startInclusive, DateTime endInclusive);
 

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryImpl.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryImpl.java
@@ -25,14 +25,11 @@ public class UtilizationHistoryImpl implements UtilizationHistory {
     }
 
     @Override
-    public Utilization getLatest() {
+    public Optional<Utilization> getLatest() {
         Set<Utilization> utilizations = utilizationRepository.findLatestUtilization(utilizationKey.facilityId);
         return utilizations.stream()
                 .filter(u -> u.getUtilizationKey().equals(utilizationKey))
-                .findAny()
-                .orElseGet(() -> {
-                    throw new IllegalStateException(utilizationKey + " was not found in " + utilizations);
-                });
+                .findAny();
     }
 
     @Override

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryImpl.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryImpl.java
@@ -11,6 +11,7 @@ import fi.hsl.parkandride.core.domain.UtilizationKey;
 import org.joda.time.DateTime;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class UtilizationHistoryImpl implements UtilizationHistory {
@@ -44,5 +45,10 @@ public class UtilizationHistoryImpl implements UtilizationHistory {
         DateTime start = startExclusive.plusMillis(1);
         DateTime end = new DateTime().plusYears(1);
         return utilizationRepository.findUtilizationsBetween(utilizationKey, start, end);
+    }
+
+    @Override
+    public Optional<Utilization> getAt(DateTime instant) {
+        return utilizationRepository.findUtilizationAtInstant(utilizationKey, instant);
     }
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryList.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryList.java
@@ -5,13 +5,13 @@ package fi.hsl.parkandride.core.domain.prediction;
 
 import com.mysema.commons.lang.CloseableIterator;
 import com.mysema.commons.lang.IteratorAdapter;
-import fi.hsl.parkandride.core.back.UtilizationRepository;
 import fi.hsl.parkandride.core.domain.Utilization;
-import fi.hsl.parkandride.core.domain.UtilizationKey;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeComparator;
 
-import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
@@ -40,8 +40,16 @@ public class UtilizationHistoryList implements UtilizationHistory {
     public CloseableIterator<Utilization> getUpdatesSince(DateTime startExclusive) {
         return new IteratorAdapter<Utilization>(
                 utilizationList.stream()
-                .filter(utilization -> utilization.timestamp.isAfter(startExclusive))
+                .filter(utilization -> !utilization.timestamp.isBefore(startExclusive))
                 .iterator()
         );
+    }
+
+    @Override
+    public Optional<Utilization> getAt(DateTime timestamp) {
+        return utilizationList.stream()
+                .filter(Objects::nonNull)
+                .filter(u -> !u.timestamp.isAfter(timestamp))
+                .max((u1, u2) -> u1.timestamp.compareTo(u2.timestamp));
     }
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryList.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryList.java
@@ -25,8 +25,9 @@ public class UtilizationHistoryList implements UtilizationHistory {
     }
 
     @Override
-    public Utilization getLatest() {
-        return utilizationList.stream().reduce(utilizationList.get(0), BinaryOperator.maxBy((a, b) -> a.timestamp.compareTo(b.timestamp)));
+    public Optional<Utilization> getLatest() {
+        return Optional.of(utilizationList.stream()
+                .reduce(utilizationList.get(0), BinaryOperator.maxBy((a, b) -> a.timestamp.compareTo(b.timestamp))));
     }
 
     @Override

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/AbstractPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/AbstractPredictorTest.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -30,10 +31,11 @@ public abstract class AbstractPredictorTest extends AbstractDaoTest {
     @Inject private UtilizationRepository utilizationRepository;
     private final Predictor predictor;
 
-    private UtilizationKey utilizationKey;
-    private UtilizationHistory utilizationHistory;
+    protected UtilizationKey utilizationKey;
+    protected UtilizationHistory utilizationHistory;
     protected PredictorState predictorState;
     protected final DateTime now = new DateTime();
+    protected Optional<Utilization> latestInsertedUtilization = Optional.empty();
 
     protected AbstractPredictorTest(Predictor predictor) {
         this.predictor = predictor;
@@ -55,6 +57,9 @@ public abstract class AbstractPredictorTest extends AbstractDaoTest {
         u.timestamp = timestamp;
         u.spacesAvailable = spacesAvailable;
         utilizationRepository.insertUtilizations(Collections.singletonList(u));
+        if (!latestInsertedUtilization.isPresent() || latestInsertedUtilization.get().timestamp.isBefore(timestamp)) {
+            latestInsertedUtilization = Optional.of(u);
+        }
     }
 
     public List<Prediction> predict() {

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/AbstractPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/AbstractPredictorTest.java
@@ -12,11 +12,18 @@ import fi.hsl.parkandride.core.domain.Utilization;
 import fi.hsl.parkandride.core.domain.UtilizationKey;
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.junit.Test;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+@Transactional
 public abstract class AbstractPredictorTest extends AbstractDaoTest {
 
     @Inject private Dummies dummies;
@@ -52,5 +59,10 @@ public abstract class AbstractPredictorTest extends AbstractDaoTest {
 
     public List<Prediction> predict() {
         return predictor.predict(predictorState, utilizationHistory);
+    }
+
+    @Test
+    public void when_no_history_then_no_predictions() {
+        assertThat(predict(), is(empty()));
     }
 }

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/AverageOfPreviousWeeksPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/AverageOfPreviousWeeksPredictorTest.java
@@ -6,13 +6,11 @@ package fi.hsl.parkandride.core.domain.prediction;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Transactional
 public class AverageOfPreviousWeeksPredictorTest extends AbstractPredictorTest {
 
     public AverageOfPreviousWeeksPredictorTest() {
@@ -28,13 +26,6 @@ public class AverageOfPreviousWeeksPredictorTest extends AbstractPredictorTest {
     @After
     public void checkUpdatesLatestUtilization() {
         assertThat(predictorState.latestUtilization).isEqualTo(now);
-    }
-
-    @Test
-    public void when_no_history_then_no_predictions() {
-        List<Prediction> predictions = predict();
-
-        assertThat(predictions).isEmpty();
     }
 
     @Test

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictorTest.java
@@ -4,7 +4,6 @@
 package fi.hsl.parkandride.core.domain.prediction;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,15 +18,13 @@ public class RelativizedAverageOfPreviousWeeksPredictorTest extends AbstractPred
         super(new RelativizedAverageOfPreviousWeeksPredictor());
     }
 
-    @Before
-    public void defineCurrentTime() {
-        // the predictor is independent of system time, so the latest utilization defines "now"
-        insertUtilization(now, 0);
-    }
+    // the predictor is independent of system time, so the latest utilization defines "now"
 
     @After
     public void checkUpdatesLatestUtilization() {
-        assertThat(predictorState.latestUtilization).isEqualTo(now);
+        if (latestInsertedUtilization.isPresent()) {
+            assertThat(predictorState.latestUtilization).isEqualTo(latestInsertedUtilization.get().timestamp);
+        }
     }
 
     @Test
@@ -40,12 +37,13 @@ public class RelativizedAverageOfPreviousWeeksPredictorTest extends AbstractPred
     }
 
     @Test
-    public void when_1_week_old_history_exists_but_no_recent_data_then_predicts_same_as_one_week_ago() {
+    public void when_1_week_old_history_exists_and_recent_utilization_is_at_same_level_then_predicts_similar_to_last_weeks_utilization() {
         insertUtilization(now.minusDays(7), 10);
         insertUtilization(now.minusDays(7).plusMinutes(5), 11);
         insertUtilization(now.minusDays(7).plusMinutes(10), 12);
         insertUtilization(now.minusDays(7).plusMinutes(15), 13);
         insertUtilization(now.minusDays(7).plusMinutes(20), 14);
+        insertUtilization(now, 10);
 
         List<Prediction> predictions = predict();
 
@@ -55,5 +53,35 @@ public class RelativizedAverageOfPreviousWeeksPredictorTest extends AbstractPred
                 new Prediction(now.plusMinutes(10), 12),
                 new Prediction(now.plusMinutes(15), 13),
                 new Prediction(now.plusMinutes(20), 14));
+    }
+
+    @Test
+    public void when_1_week_old_and_recent_history_have_same_trend_but_different_level_then_prediction_adapts_to_current_utilization_level() {
+        insertUtilization(now.minusDays(7).minusMinutes(20), 6);
+        insertUtilization(now.minusDays(7).minusMinutes(15), 7);
+        insertUtilization(now.minusDays(7).minusMinutes(10), 8);
+        insertUtilization(now.minusDays(7).minusMinutes(5), 9);
+        insertUtilization(now.minusDays(7), 10);
+        insertUtilization(now.minusDays(7).plusMinutes(5), 11);
+        insertUtilization(now.minusDays(7).plusMinutes(10), 12);
+        insertUtilization(now.minusDays(7).plusMinutes(15), 13);
+        insertUtilization(now.minusDays(7).plusMinutes(20), 14);
+
+        insertUtilization(now.minusMinutes(20), 16);
+        insertUtilization(now.minusMinutes(15), 17);
+        insertUtilization(now.minusMinutes(10), 18);
+        insertUtilization(now.minusMinutes(5), 19);
+
+        List<Prediction> predictions = predict();
+
+        assertThat(utilizationHistory.getLatest())
+                .isPresent();
+        assertThat(utilizationHistory.getLatest().get().spacesAvailable).isEqualTo(19);
+        assertThat(predictions).containsSubsequence(
+                new Prediction(now, 20),
+                new Prediction(now.plusMinutes(5), 21),
+                new Prediction(now.plusMinutes(10), 22),
+                new Prediction(now.plusMinutes(15), 23),
+                new Prediction(now.plusMinutes(20), 24));
     }
 }

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictorTest.java
@@ -1,0 +1,59 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain.prediction;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+public class RelativizedAverageOfPreviousWeeksPredictorTest extends AbstractPredictorTest {
+
+    public RelativizedAverageOfPreviousWeeksPredictorTest() {
+        super(new RelativizedAverageOfPreviousWeeksPredictor());
+    }
+
+    @Before
+    public void defineCurrentTime() {
+        // the predictor is independent of system time, so the latest utilization defines "now"
+        insertUtilization(now, 0);
+    }
+
+    @After
+    public void checkUpdatesLatestUtilization() {
+        assertThat(predictorState.latestUtilization).isEqualTo(now);
+    }
+
+    @Test
+    public void when_less_than_6_days_of_history_then_no_predictions() {
+        insertUtilization(now.minusDays(6).plusSeconds(1), 666);
+
+        List<Prediction> predictions = predict();
+
+        assertThat(predictions).isEmpty();
+    }
+
+    @Test
+    public void when_1_week_old_history_exists_but_no_recent_data_then_predicts_same_as_one_week_ago() {
+        insertUtilization(now.minusDays(7), 10);
+        insertUtilization(now.minusDays(7).plusMinutes(5), 11);
+        insertUtilization(now.minusDays(7).plusMinutes(10), 12);
+        insertUtilization(now.minusDays(7).plusMinutes(15), 13);
+        insertUtilization(now.minusDays(7).plusMinutes(20), 14);
+
+        List<Prediction> predictions = predict();
+
+        assertThat(predictions).containsSubsequence(
+                new Prediction(now, 10),
+                new Prediction(now.plusMinutes(5), 11),
+                new Prediction(now.plusMinutes(10), 12),
+                new Prediction(now.plusMinutes(15), 13),
+                new Prediction(now.plusMinutes(20), 14));
+    }
+}

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictorTest.java
@@ -146,4 +146,34 @@ public class RelativizedAverageOfPreviousWeeksPredictorTest extends AbstractPred
                 new Prediction(now.plusMinutes(15), 26),
                 new Prediction(now.plusMinutes(20), 30));
     }
+
+    @Test
+    public void available_spaces_cannot_go_to_negative_values() {
+        insertUtilization(now.minusDays(7).minus(LOOKBACK_MINUTES), 20);
+        insertUtilization(now.minusDays(7).minusMinutes(15), 19);
+        insertUtilization(now.minusDays(7).minusMinutes(10), 18);
+        insertUtilization(now.minusDays(7).minusMinutes(5), 17);
+        insertUtilization(now.minusDays(7), 16);
+        insertUtilization(now.minusDays(7).plusMinutes(5), 15);
+        insertUtilization(now.minusDays(7).plusMinutes(10), 14);
+        insertUtilization(now.minusDays(7).plusMinutes(15), 13);
+        insertUtilization(now.minusDays(7).plusMinutes(20), 12);
+
+        insertUtilization(now.minus(LOOKBACK_MINUTES), 4);
+        insertUtilization(now.minusMinutes(15), 3);
+        insertUtilization(now.minusMinutes(10), 2);
+        insertUtilization(now.minusMinutes(5), 1);
+
+        List<Prediction> predictions = predict();
+
+        assertThat(utilizationHistory.getLatest())
+                .isPresent();
+        assertThat(utilizationHistory.getLatest().get().spacesAvailable).isEqualTo(1);
+        assertThat(predictions).containsSubsequence(
+                new Prediction(now, 0),
+                new Prediction(now.plusMinutes(5), 0),
+                new Prediction(now.plusMinutes(10), 0),
+                new Prediction(now.plusMinutes(15), 0),
+                new Prediction(now.plusMinutes(20), 0));
+    }
 }

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/SameAsLatestPredictorTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/SameAsLatestPredictorTest.java
@@ -3,27 +3,17 @@
 
 package fi.hsl.parkandride.core.domain.prediction;
 
-import org.joda.time.DateTime;
 import org.junit.Test;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-@Transactional
 public class SameAsLatestPredictorTest extends AbstractPredictorTest {
 
     public SameAsLatestPredictorTest() {
         super(new SameAsLatestPredictor());
-    }
-
-    @Test
-    public void when_no_history_then_no_predictions() {
-        assertThat(predict(), is(empty()));
-        assertThat(predictorState.latestUtilization, is(new DateTime(0)));
     }
 
     @Test

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryListTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryListTest.java
@@ -52,7 +52,8 @@ public class UtilizationHistoryListTest {
     public static class GetLatest extends Base {
         @Test
         public void latest_utilization_is_returned() throws Exception {
-            assertThat(historyList.getLatest().timestamp).isEqualTo(LATEST_DATETIME);
+            assertThat(historyList.getLatest()).isPresent();
+            assertThat(historyList.getLatest().get().timestamp).isEqualTo(LATEST_DATETIME);
         }
     }
 

--- a/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryListTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/domain/prediction/UtilizationHistoryListTest.java
@@ -1,0 +1,131 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.domain.prediction;
+
+import fi.hsl.parkandride.core.domain.Utilization;
+import org.assertj.core.api.Condition;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static fi.hsl.parkandride.core.domain.CapacityType.CAR;
+import static fi.hsl.parkandride.core.domain.Usage.HSL_TRAVEL_CARD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Enclosed.class)
+public class UtilizationHistoryListTest {
+
+    static final DateTime LATEST_DATETIME = new DateTime(2015, 10, 23, 14, 0);
+    static final Long FACILITY_ID = 123L;
+    static final DateTime RANGE_START_DATETIME = LATEST_DATETIME.minusMinutes(20);
+    static final DateTime RANGE_END_DATETIME = LATEST_DATETIME.minusMinutes(10);
+
+    public static abstract class Base {
+        protected List<Utilization> utilizationList;
+        protected UtilizationHistoryList historyList;
+
+        @Before
+        public void setUp() throws Exception {
+            utilizationList = Arrays.asList(
+                    newUtilization(LATEST_DATETIME.minusMinutes(25), 50),
+                    newUtilization(LATEST_DATETIME.minusMinutes(20), 40),
+                    newUtilization(LATEST_DATETIME.minusMinutes(15), 30),
+                    newUtilization(LATEST_DATETIME.minusMinutes(10), 20),
+                    newUtilization(LATEST_DATETIME.minusMinutes(5), 15),
+                    newUtilization(LATEST_DATETIME, 10));
+            historyList = new UtilizationHistoryList(utilizationList);
+        }
+
+        @After
+        public void tearDown() throws Exception {
+        }
+    }
+
+    public static class GetLatest extends Base {
+        @Test
+        public void latest_utilization_is_returned() throws Exception {
+            assertThat(historyList.getLatest().timestamp).isEqualTo(LATEST_DATETIME);
+        }
+    }
+
+    public static class GetRange extends Base {
+        @Test
+        public void when_start_and_end_timestamps_match_entries_then_boundary_entries_must_be_included() throws Exception {
+            assertThat(historyList.getRange(RANGE_START_DATETIME, RANGE_END_DATETIME))
+                    .areNot(new TimestampBefore(RANGE_START_DATETIME))
+                    .areNot(new TimestampAfter(RANGE_END_DATETIME))
+                    .hasSize(3);
+        }
+    }
+
+    public static class GetUpdatesSince extends Base {
+        @Test
+        public void getUpdatesSince_is_inclusive() throws Exception {
+            assertThat(historyList.getUpdatesSince(RANGE_START_DATETIME))
+                    .areNot(new TimestampBefore(RANGE_START_DATETIME))
+                    .hasSize(5);
+        }
+    }
+
+    public static class  GetAt extends Base {
+        @Test
+        public void when_getAt_is_called_with_matching_timestamp_then_Utilization_with_matching_timestamp_is_returned() {
+            assertThat(historyList.getAt(LATEST_DATETIME.minusMinutes(5)))
+                    .isPresent()
+                    .contains(newUtilization(LATEST_DATETIME.minusMinutes(5), 15));
+        }
+
+        @Test
+        public void when_getAt_is_called_with_non_matching_timestamp_then_Utilization_with_closest_previous_timestamp_is_returned() {
+            assertThat(historyList.getAt(LATEST_DATETIME.minusMinutes(1)))
+                    .isPresent()
+                    .contains(newUtilization(LATEST_DATETIME.minusMinutes(5), 15));
+        }
+    }
+
+    private static Utilization newUtilization(DateTime time, int spacesAvailable) {
+        Utilization u = new Utilization();
+        u.facilityId = FACILITY_ID;
+        u.capacityType = CAR;
+        u.usage = HSL_TRAVEL_CARD;
+        u.timestamp = time;
+        u.spacesAvailable = spacesAvailable;
+        return u;
+    }
+
+    private static class TimestampAfter extends Condition<Utilization> {
+        private final DateTime lowerBound;
+
+        public TimestampAfter(DateTime lowerBound) {
+            super("After " + lowerBound);
+            this.lowerBound = lowerBound;
+        }
+
+        @Override
+        public boolean matches(Utilization utilization) {
+            return utilization.timestamp.isAfter(lowerBound);
+        }
+    }
+
+    private static class TimestampBefore extends Condition<Utilization> {
+        private final DateTime upperBound;
+
+        public TimestampBefore(DateTime upperBound) {
+            super("Before " + upperBound);
+            this.upperBound = upperBound;
+        }
+
+        @Override
+        public boolean matches(Utilization utilization) {
+            return utilization.timestamp.isBefore(upperBound);
+        }
+    }
+}


### PR DESCRIPTION
Implemented a simple predictor that uses the average parking facility utilization from 3 previous weeks as the basis for predicting parking facility utilization/availability, but also adapts to the current level of utilization and the magnitude of changes during the last 2 hours.