### PR TITLE
LIIP-282: make report end date inclusive

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/core/service/reporting/AbstractReportService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/reporting/AbstractReportService.java
@@ -60,9 +60,9 @@ public abstract class AbstractReportService extends ReportServiceSupport impleme
         UtilizationSearch search = new UtilizationSearch();
         search.start = parameters.startDate.toDateTimeAtStartOfDay();
         if (parameters.endDate == null) {
-            search.end = new LocalDate().plusDays(1).toDateTimeAtStartOfDay();
+            search.end = new LocalDate().plusDays(1).toDateTimeAtStartOfDay().millisOfDay().withMaximumValue();
         } else {
-            search.end = parameters.endDate.toDateTimeAtStartOfDay();
+            search.end = parameters.endDate.toDateTimeAtStartOfDay().millisOfDay().withMaximumValue();
         }
         if (!isEmpty(parameters.capacityTypes)) {
             search.capacityTypes = parameters.capacityTypes;

--- a/application/src/test/java/fi/hsl/parkandride/itest/AbstractReportingITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/AbstractReportingITest.java
@@ -205,7 +205,8 @@ public abstract class AbstractReportingITest extends AbstractIntegrationTest {
     }
 
     protected List<String> getDataFromRow(Sheet sheet, int rownum) {
-        return getDataFromRow(sheet.getRow(rownum));
+        final Row row = sheet.getRow(rownum);
+        return row == null ? null : getDataFromRow(row);
     }
 
     protected List<String> getDataFromRow(Row row) {

--- a/application/src/test/java/fi/hsl/parkandride/itest/MaxUtilizationReportITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/MaxUtilizationReportITest.java
@@ -311,6 +311,29 @@ public class MaxUtilizationReportITest extends AbstractReportingITest {
         });
     }
 
+    @Test
+    public void testThat_startAndEndDateAreInclusive() {
+        final ReportParameters params = baseParams();
+        params.startDate = new LocalDate(2015, 10, 1); // Thursday
+        params.endDate = new LocalDate(2015, 10, 31); // Saturday
+
+        facilityService.registerUtilization(facility1.id, asList(
+                utilize(CAR, 10, params.startDate.toDateTimeAtCurrentTime(), facility1),
+                utilize(CAR, 20, params.endDate.toDateTimeAtCurrentTime(), facility1)
+        ), apiUser);
+        facilityService.registerUtilization(facility2.id, asList(
+                utilize(CAR, 0, params.startDate.toDateTimeAtCurrentTime(), facility2),
+                utilize(CAR, 0, params.endDate.toDateTimeAtCurrentTime(), facility2)
+        ), apiUser2);
+
+        final Response whenPostingToReportUrl = postToReportUrl(params, MAX_UTILIZATION, adminUser);
+        checkSheetContents(whenPostingToReportUrl, 0,
+                headers(),
+                hubRow(asList(operator1, operator2), PARK_AND_RIDE, CAR, DayType.BUSINESS_DAY, 100, 0, 0.9),
+                hubRow(asList(operator1, operator2), PARK_AND_RIDE, CAR, DayType.SATURDAY, 100, 0, 0.8)
+        );
+    }
+
     private Utilization mockUtilize(Facility f, String date, int spaces) {
         return utilize(CAR, spaces, DateTime.parse(date), f);
     }


### PR DESCRIPTION
The selected end date was previously not included in the reporting requests. Corrects the filter to include utilization entries during the last selected day, also. 