### PR TITLE
LIIP-283: add status history to facility usage report

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/core/service/reporting/Excel.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/reporting/Excel.java
@@ -16,12 +16,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static java.lang.Math.max;
 import static java.util.Arrays.asList;
-import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
 import static org.apache.poi.ss.usermodel.Cell.*;
 
@@ -30,6 +30,8 @@ class Excel {
 
     private final Workbook wb = new XSSFWorkbook();
     private final Font font12pt = wb.createFont();
+    private final Font font12ptGreen = wb.createFont();
+    private final Font font12ptRed = wb.createFont();
     private final Font bold = wb.createFont();
     private final CellStyle title = wb.createCellStyle();
     final CellStyle text = wb.createCellStyle();
@@ -40,11 +42,22 @@ class Excel {
     final CellStyle date = wb.createCellStyle();
     final CellStyle datetime = wb.createCellStyle();
     final CellStyle month = wb.createCellStyle();
+
+    // Colorized cells
+    final CellStyle green = wb.createCellStyle();
+    final CellStyle red   = wb.createCellStyle();
+    final CellStyle yellow = wb.createCellStyle();
+    final CellStyle orange = wb.createCellStyle();
+
     private final DataFormat df = wb.createDataFormat();
     private Sheet sheet;
 
     {
         font12pt.setFontHeightInPoints((short) 12);
+        font12ptGreen.setFontHeightInPoints((short) 12);
+        font12ptGreen.setColor(IndexedColors.GREEN.index);
+        font12ptRed.setFontHeightInPoints((short) 12);
+        font12ptRed.setColor(IndexedColors.RED.index);
         bold.setFontHeightInPoints((short) 12);
         bold.setBoldweight(Font.BOLDWEIGHT_BOLD);
         title.setFont(bold);
@@ -65,25 +78,41 @@ class Excel {
         datetime.setFont(font12pt);
         month.setDataFormat(df.getFormat("M\\/yyyy"));
         month.setFont(font12pt);
+
+        // Colorized
+        green.setFont(font12ptGreen);
+        green.setFillPattern(CellStyle.SOLID_FOREGROUND);
+        green.setFillForegroundColor(IndexedColors.LIGHT_GREEN.index);
+        red.setFont(font12ptRed);
+        yellow.setFont(font12pt);
+        yellow.setFillPattern(CellStyle.SOLID_FOREGROUND);
+        yellow.setFillForegroundColor(IndexedColors.LIGHT_YELLOW.index);
+        orange.setFont(font12pt);
+        orange.setFillPattern(CellStyle.SOLID_FOREGROUND);
+        orange.setFillForegroundColor(IndexedColors.CORAL.index);
     }
 
     static class TableColumn<T> {
         static <T> TableColumn<T> col(String name, Function<T, Object> valueFunction) {
-            return new TableColumn<>(name, valueFunction, null);
+            return col(name, valueFunction, val -> null);
         }
 
         static <T> TableColumn<T> col(String name, Function<T, Object> valueFunction, CellStyle style) {
-            return new TableColumn<>(name, valueFunction, style);
+            return col(name, valueFunction, v -> style);
+        }
+
+        static <T> TableColumn<T> col(String name, Function<T, Object> valueFunction, Function<T, CellStyle> styleFn) {
+            return new TableColumn<>(name, valueFunction, styleFn);
         }
 
         public final String name;
         public final Function<T, Object> valueFunction;
-        public final CellStyle style;
+        public final Function<T, CellStyle> styleFn;
 
-        private TableColumn(String name, Function<T, Object> valueFunction, CellStyle style) {
+        private TableColumn(String name, Function<T, Object> valueFunction, Function<T, CellStyle> styleFn) {
             this.name = name;
             this.valueFunction = valueFunction;
-            this.style = style;
+            this.styleFn = styleFn;
         }
     }
 
@@ -105,33 +134,36 @@ class Excel {
             for (int column = 0; column < columns.size(); ++column) {
                 TableColumn<T> colType = columns.get(column);
                 Object value;
+                Optional<CellStyle> style;
+                final T v = rows.get(r);
                 try {
-                  value = colType.valueFunction.apply(rows.get(r));
+                  value = colType.valueFunction.apply(v);
                 } catch (RuntimeException ex) {
                   log.error("Failed to generate cell for column " + colType.name, ex);
                   value = cleanExceptionMessage(ex);
                 }
+                style = Optional.ofNullable(colType.styleFn.apply(v));
                 if (value == null) {
                     row.createCell(column, CELL_TYPE_BLANK);
                 } else if (value instanceof Double) {
                     Cell cell = row.createCell(column, CELL_TYPE_NUMERIC);
-                    cell.setCellStyle(ofNullable(colType.style).orElse(decimal));
+                    cell.setCellStyle(style.orElse(decimal));
                     cell.setCellValue((Double) value);
                 } else if (value instanceof Integer) {
                     Cell cell = row.createCell(column, CELL_TYPE_NUMERIC);
-                    cell.setCellStyle(ofNullable(colType.style).orElse(integer));
+                    cell.setCellStyle(style.orElse(integer));
                     cell.setCellValue((Integer) value);
                 } else if (value instanceof MultilingualString) {
                     Cell cell = row.createCell(column, CELL_TYPE_STRING);
-                    cell.setCellStyle(ofNullable(colType.style).orElse(text));
+                    cell.setCellStyle(style.orElse(text));
                     cell.setCellValue(((MultilingualString) value).fi);
                 } else if (value instanceof LocalDate) {
                     Cell cell = row.createCell(column, CELL_TYPE_NUMERIC);
-                    cell.setCellStyle(ofNullable(colType.style).orElse(date));
+                    cell.setCellStyle(style.orElse(date));
                     cell.setCellValue(((LocalDate) value).toDate());
                 } else if (value instanceof DateTime) {
                     Cell cell = row.createCell(column, CELL_TYPE_NUMERIC);
-                    cell.setCellStyle(ofNullable(colType.style).orElse(datetime));
+                    cell.setCellStyle(style.orElse(datetime));
                     cell.setCellValue(((DateTime) value).toDate());
                 } else if (value instanceof Collection) {
                     // currently must be last item in list
@@ -143,7 +175,9 @@ class Excel {
                 } else {
                     Cell cell = row.createCell(column, CELL_TYPE_STRING);
                     String val = value.toString();
-                    if (val.indexOf('\n') > 0) {
+                    if (style.isPresent()) {
+                        cell.setCellStyle(style.get());
+                    } else if (val.indexOf('\n') > 0) {
                         cell.setCellStyle(multiline);
                     } else {
                         cell.setCellStyle(text);

--- a/application/src/main/java/fi/hsl/parkandride/core/service/reporting/ExcelUtil.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/reporting/ExcelUtil.java
@@ -41,4 +41,8 @@ public class ExcelUtil {
     <T> Excel.TableColumn<T> tcol(String key, Function<T, Object> valFn, CellStyle cellStyle) {
         return Excel.TableColumn.col(getMessage(key), valFn, cellStyle);
     }
+
+    <T> Excel.TableColumn<T> tcol(String key, Function<T, Object> valFn, Function<T, CellStyle> styleFn) {
+        return Excel.TableColumn.col(getMessage(key), valFn, styleFn);
+    }
 }

--- a/application/src/main/java/fi/hsl/parkandride/core/service/reporting/FacilityUsageReportService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/reporting/FacilityUsageReportService.java
@@ -3,14 +3,13 @@
 
 package fi.hsl.parkandride.core.service.reporting;
 
+import com.google.common.collect.ImmutableMap;
 import com.mysema.commons.lang.CloseableIterator;
 import fi.hsl.parkandride.back.RegionRepository;
 import fi.hsl.parkandride.core.back.UtilizationRepository;
-import fi.hsl.parkandride.core.domain.Facility;
-import fi.hsl.parkandride.core.domain.Hub;
-import fi.hsl.parkandride.core.domain.Utilization;
-import fi.hsl.parkandride.core.domain.UtilizationSearch;
+import fi.hsl.parkandride.core.domain.*;
 import fi.hsl.parkandride.core.service.*;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -21,14 +20,16 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static fi.hsl.parkandride.core.domain.DayType.*;
+import static fi.hsl.parkandride.core.domain.FacilityStatus.*;
 import static fi.hsl.parkandride.util.ArgumentValidator.validate;
 import static java.time.LocalTime.ofSecondOfDay;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.fill;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.*;
 
 public class FacilityUsageReportService extends AbstractReportService {
 
@@ -53,6 +54,8 @@ public class FacilityUsageReportService extends AbstractReportService {
                     .forEachRemaining(setValueToLatestFreeSpacesInWindow(ctx, intervalSeconds, reportRows));
         }
 
+        addDayToDayStatusInformation(reportRows, parameters.startDate, parameters.endDate);
+
         Excel excel = new Excel();
 
         List<UtilizationReportRow> rows = reportRows.values()
@@ -64,6 +67,12 @@ public class FacilityUsageReportService extends AbstractReportService {
                 )
                 .collect(toList());
 
+        Map<FacilityStatus, CellStyle> colors = ImmutableMap.of(
+                IN_OPERATION, excel.green,
+                EXCEPTIONAL_SITUATION, excel.yellow,
+                TEMPORARILY_CLOSED, excel.orange,
+                INACTIVE, excel.red
+        );
         List<Excel.TableColumn<UtilizationReportRow>> columns = asList(
                 excelUtil.tcol("reports.usage.col.facility", (UtilizationReportRow r) -> r.key.facility.name),
                 excelUtil.tcol("reports.usage.col.hub", (UtilizationReportRow r) -> ctx.hubsByFacilityId.getOrDefault(r.key.targetId, emptyList()).stream().map((Hub h) -> h.name.fi).collect(joining(", "))),
@@ -71,7 +80,7 @@ public class FacilityUsageReportService extends AbstractReportService {
                 excelUtil.tcol("reports.usage.col.operator", (UtilizationReportRow r) -> operatorService.getOperator(r.key.facility.operatorId).name),
                 excelUtil.tcol("reports.usage.col.usage", (UtilizationReportRow r) -> translationService.translate(r.key.usage)),
                 excelUtil.tcol("reports.usage.col.capacityType", (UtilizationReportRow r) -> translationService.translate(r.key.capacityType)),
-                excelUtil.tcol("reports.usage.col.status", (UtilizationReportRow r) -> translationService.translate(r.key.facility.status)),
+                excelUtil.tcol("reports.usage.col.status", (UtilizationReportRow r) -> translationService.translate(r.effectiveStatus), (UtilizationReportRow r) -> colors.get(r.effectiveStatus)),
                 excelUtil.tcol("reports.usage.col.openingHoursBusinessDay", (UtilizationReportRow r) -> ExcelUtil.time(r.key.facility.openingHours.byDayType.get(BUSINESS_DAY))),
                 excelUtil.tcol("reports.usage.col.openingHoursSaturday", (UtilizationReportRow r) -> ExcelUtil.time(r.key.facility.openingHours.byDayType.get(SATURDAY))),
                 excelUtil.tcol("reports.usage.col.openingHoursSunday", (UtilizationReportRow r) -> ExcelUtil.time(r.key.facility.openingHours.byDayType.get(SUNDAY))),
@@ -87,6 +96,18 @@ public class FacilityUsageReportService extends AbstractReportService {
         excel.addSheet(excelUtil.getMessage("reports.usage.sheets.legend"),
                 excelUtil.getMessage("reports.usage.legend").split("\n"));
         return excel;
+    }
+
+    private void addDayToDayStatusInformation(Map<UtilizationReportKey, UtilizationReportRow> reportRows, LocalDate startDate, LocalDate endDate) {
+        final Map<Long, Map<LocalDate, FacilityStatus>> statusHistory = reportRows.keySet().stream()
+                .map(key -> key.facility.id)
+                .distinct()
+                .collect(toMap(
+                        identity(),
+                        id -> facilityHistoryService.getStatusHistoryByDay(id, startDate, endDate)
+                ));
+        reportRows.forEach((key, row) -> row.effectiveStatus = statusHistory.getOrDefault(key.facility.id, emptyMap())
+                .getOrDefault(key.date, key.facility.status));
     }
 
     private Consumer<Utilization> setValueToLatestFreeSpacesInWindow(ReportContext ctx, int intervalSeconds, Map<UtilizationReportKey, UtilizationReportRow> reportRows) {
@@ -143,6 +164,7 @@ public class FacilityUsageReportService extends AbstractReportService {
         private final int intervalSeconds;
         final UtilizationReportKey key;
         final int[] values;
+        FacilityStatus effectiveStatus;
 
         UtilizationReportRow(UtilizationReportKey key, int intervalSeconds, int initialValue) {
             this.key = key;

--- a/application/src/test/java/fi/hsl/parkandride/itest/AbstractReportingITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/AbstractReportingITest.java
@@ -43,6 +43,7 @@ import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
+import static org.joda.time.DateTimeConstants.MONDAY;
 
 public abstract class AbstractReportingITest extends AbstractIntegrationTest {
     protected static final DateTime BASE_DATE_TIME = LocalDate.now().minusMonths(1).withDayOfMonth(15).toDateTime(LocalTime.parse("12:37"));
@@ -51,6 +52,15 @@ public abstract class AbstractReportingITest extends AbstractIntegrationTest {
     protected static final String MONTH_FORMAT = "M/yyyy";
     protected static final String DATE_FORMAT = "d.M.yyyy";
     protected static final String DATETIME_FORMAT = "d.M.yyyy HH:mm";
+
+    protected static final DateTime baseDate = BASE_DATE.toDateTime(new LocalTime("7:59")).withDayOfMonth(15);
+    protected static final DateTime mon = baseDate.withDayOfWeek(MONDAY);
+    protected static final DateTime tue = mon.plusDays(1);
+    protected static final DateTime wed = mon.plusDays(2);
+    protected static final DateTime fri = mon.plusDays(4);
+    protected static final DateTime sat = mon.plusDays(5);
+    protected static final DateTime sun = mon.plusDays(6);
+    protected static final DateTime initial = mon.minusMonths(1);
 
     protected User adminUser;
     protected User apiUser;

--- a/application/src/test/java/fi/hsl/parkandride/itest/AbstractReportingITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/AbstractReportingITest.java
@@ -46,7 +46,7 @@ import static java.util.stream.StreamSupport.stream;
 import static org.joda.time.DateTimeConstants.MONDAY;
 
 public abstract class AbstractReportingITest extends AbstractIntegrationTest {
-    protected static final DateTime BASE_DATE_TIME = LocalDate.now().minusMonths(1).withDayOfMonth(15).toDateTime(LocalTime.parse("12:37"));
+    protected static final DateTime BASE_DATE_TIME = new DateTime(2015, 9, 15, 12, 37);
     protected static final DateTime ROUNDED_BASE_DATETIME = BASE_DATE_TIME.withMinuteOfHour(0);
     protected static final LocalDate BASE_DATE = BASE_DATE_TIME.toLocalDate();
     protected static final String MONTH_FORMAT = "M/yyyy";

--- a/application/src/test/java/fi/hsl/parkandride/itest/MaxUtilizationReportITest.java
+++ b/application/src/test/java/fi/hsl/parkandride/itest/MaxUtilizationReportITest.java
@@ -12,7 +12,6 @@ import fi.hsl.parkandride.core.service.FacilityHistoryService;
 import fi.hsl.parkandride.core.service.reporting.ReportParameters;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,14 +39,7 @@ public class MaxUtilizationReportITest extends AbstractReportingITest {
     private static final String MAX_UTILIZATION = "MaxUtilization";
 
     // Day 15 to ensure that weekdays stay in the same month
-    private static final DateTime baseDate = BASE_DATE.toDateTime(new LocalTime("7:59")).withDayOfMonth(15);
-    private static final DateTime mon = baseDate.withDayOfWeek(MONDAY);
-    private static final DateTime tue = mon.plusDays(1);
-    private static final DateTime wed = mon.plusDays(2);
-    private static final DateTime fri = mon.plusDays(4);
-    private static final DateTime sat = mon.plusDays(5);
-    private static final DateTime sun = mon.plusDays(6);
-    private static final DateTime initial = mon.minusMonths(1);
+
     private static final int UNAVAILABLE_COLUMN = 6;
 
     @Inject FacilityHistoryRepository facilityHistoryRepository;


### PR DESCRIPTION
Adds historical status information to max utilization report as per [LIIP-283](https://hsl-liipi.atlassian.net/browse/LIIP-283). If the status changed during a day, the one that was longest in effect during 6-10 is selected.

- [x] add status history
- [x] colorize states