### PR TITLE
Disable UI tests for GoCD release build

### DIFF
--- a/etc/scripts/gocd/build/build-release.sh
+++ b/etc/scripts/gocd/build/build-release.sh
@@ -40,7 +40,7 @@ function run() {
       -DnewVersion="$version" \
       --file parent/pom.xml
 
-  mvn clean deploy \
+  mvn -Pnoui clean deploy \
       --update-snapshots \
       --batch-mode \
       --errors \


### PR DESCRIPTION
Disable the UI tests from the main build task to speed up the build process. The tests were previously run twice by the GoCD server.