### PR TITLE
Step 1 in fixing concurrency errors in related to prediction calculations

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.function.BinaryOperator;
@@ -38,6 +39,9 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 import static org.joda.time.Duration.standardHours;
 import static org.joda.time.Duration.standardMinutes;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
+import static org.springframework.transaction.annotation.Propagation.REQUIRED;
 
 public class PredictionDao implements PredictionRepository {
 
@@ -63,7 +67,7 @@ public class PredictionDao implements PredictionRepository {
         this.validationService = validationService;
     }
 
-    @TransactionalWrite
+    @Transactional(readOnly = false, isolation = SERIALIZABLE, propagation = REQUIRED)
     @Override
     public void updatePredictions(PredictionBatch pb, Long predictorId) {
         validationService.validate(pb);


### PR DESCRIPTION
Changed prediction updating to use serializable transaction isolation in order to notice when writing fails due to race condition with another server in cluster. This should make it possible to reliably identify the race condition (and not make false matches on other errors). Deploying this minimal PR to dev/test should make it possible to verify the nature of the problem: the exception thrown should change from constraint violation to concurrency violation due to the strict isolation level.