### PR TITLE
Disable predictor if not installed

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/prediction/RelativizedAverageOfPreviousWeeksPredictor.java
@@ -42,7 +42,6 @@ public class RelativizedAverageOfPreviousWeeksPredictor implements Predictor {
         List<List<Prediction>> groupedByWeek =
                 LOOKBACK_PERIODS.stream()
                         .map(offset -> {
-                            offset.toMutablePeriod().add(PredictionRepository.PREDICTION_WINDOW);
                             DateTime start = now.minus(offset);
                             DateTime end = start.plus(PredictionRepository.PREDICTION_WINDOW);
                             Optional<Utilization> utilizationAtReferenceTime = inMemoryHistory.getAt(start);


### PR DESCRIPTION
Fix problem caused by replacing a predictor with a new one: if old, replaced predictor has moreUtilizations=true in database, then the scheduled prediction job tries to update predictions with the predictor, but when failing to find the old predictor from its list of installed predictors, logs a warning. This happened every 5 minutes as the moreUtilizations did not get set to false. Now, moreUtilizations is set to false even for those predictors that are not installed. This should stop the system generating warnings about this situation (warning is generated only the first time after a predictor is uninstalled).