### PR TITLE
Liip 286 reduce prediction history data

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
@@ -55,12 +55,13 @@ public class PredictionDao implements PredictionRepository {
                             p -> p.getMetadata().getName().substring("spacesAvailableAt".length()),
                             Function.identity())));
 
-    private final PostgreSQLQueryFactory queryFactory;
-    private final ValidationService validationService;
-    private final List<Duration> predictionsDistancesToStore = Collections.unmodifiableList(
+    public static final List<Duration> predictionsDistancesToStore = Collections.unmodifiableList(
             Arrays.<Duration>asList(standardMinutes(5), standardMinutes(10), standardMinutes(15), standardMinutes(20),
                     standardMinutes(30), standardMinutes(45), standardHours(1), standardHours(2), standardHours(4),
                     standardHours(8), standardHours(12), standardHours(16), standardHours(20), standardHours(24)));
+
+    private final PostgreSQLQueryFactory queryFactory;
+    private final ValidationService validationService;
 
     public PredictionDao(PostgreSQLQueryFactory queryFactory, ValidationService validationService) {
         this.queryFactory = queryFactory;
@@ -80,7 +81,7 @@ public class PredictionDao implements PredictionRepository {
             initializePredictionLookupTable(utilizationKey);
             updatePredictions(pb, predictorId); // retry now that the lookup table exists
         } else {
-            savePredictionHistory(predictorId, start, predictions);
+            savePredictionHistory(predictorId, start, filterToSelectedPredictionDistances(start, predictions));
         }
     }
 

--- a/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
@@ -90,10 +90,13 @@ public class PredictionDao implements PredictionRepository {
         validationService.validate(pb);
         DateTime start = toPredictionResolution(pb.sourceTimestamp);
         List<Prediction> predictions = normalizeToPredictionWindow(start, pb.predictions);
-        predictions = predictions.stream()
+        savePredictionHistory(predictorId, start, filterToSelectedPredictionDistances(start, predictions));
+    }
+
+    private List<Prediction> filterToSelectedPredictionDistances(DateTime start, List<Prediction> predictions) {
+        return predictions.stream()
                 .filter(p -> predictionsDistancesToStore.contains(new Duration(start, p.timestamp)))
                 .collect(toList());
-        savePredictionHistory(predictorId, start, predictions);
     }
 
     private static List<Prediction> normalizeToPredictionWindow(DateTime start, List<Prediction> predictions) {

--- a/application/src/test/java/fi/hsl/parkandride/back/prediction/PredictionDaoTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/back/prediction/PredictionDaoTest.java
@@ -15,6 +15,7 @@ import fi.hsl.parkandride.core.domain.prediction.PredictionBatch;
 import fi.hsl.parkandride.core.service.ValidationException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -291,8 +292,13 @@ public class PredictionDaoTest extends AbstractDaoTest {
                 .mapToObj(counter -> counter * PREDICTION_RESOLUTION.getMinutes())
                 .forEach(predictionDistanceInMinutes -> {
                     List<Prediction> predictionHistory = predictionDao.getPredictionHistoryByPredictor(predictorId, now, now.plus(PREDICTION_WINDOW), predictionDistanceInMinutes);
-                    assertThat(predictionHistory).as("Prediction history for prediction distance %d minutes", predictionDistanceInMinutes)
-                            .containsOnly(new Prediction(toPredictionResolution(now.plusMinutes(predictionDistanceInMinutes)), 666));
+                    if (PredictionDao.predictionsDistancesToStore.contains(Duration.standardMinutes(predictionDistanceInMinutes))) {
+                        assertThat(predictionHistory).as("Prediction history for prediction distance %d minutes exists", predictionDistanceInMinutes)
+                                .containsOnly(new Prediction(toPredictionResolution(now.plusMinutes(predictionDistanceInMinutes)), 666));
+                    } else {
+                        assertThat(predictionHistory).as("Prediction history for prediction distance %d minutes does not exist", predictionDistanceInMinutes)
+                                .isEmpty();
+                    }
                 });
     }
 


### PR DESCRIPTION
Reduce the volume of stored prediction history data by about 95%. In practice, the prediction history is now stored for only these prediction distances: 5, 10, 15, 20, 30 and 45 minutes, as well as 1, 2, 4, 8, 12, 16, 20 and 24 hours (total of 14 prediction distances). The previous version stored prediction history for 24 hours with 5 minute steps resulting in 24*12 = 288 prediction distances stored every 5 minutes for each facility (and for each different capacity & usage combination within it).