### PR TITLE
Fix prediction generation concurrency in cluster

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/prediction/PredictionDao.java
@@ -26,7 +26,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.function.BinaryOperator;
@@ -39,9 +38,6 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 import static org.joda.time.Duration.standardHours;
 import static org.joda.time.Duration.standardMinutes;
-import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
-import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
-import static org.springframework.transaction.annotation.Propagation.REQUIRED;
 
 public class PredictionDao implements PredictionRepository {
 
@@ -68,7 +64,7 @@ public class PredictionDao implements PredictionRepository {
         this.validationService = validationService;
     }
 
-    @Transactional(readOnly = false, isolation = SERIALIZABLE, propagation = REQUIRED)
+    @TransactionalWrite
     @Override
     public void updatePredictions(PredictionBatch pb, Long predictorId) {
         validationService.validate(pb);

--- a/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
@@ -103,6 +103,10 @@ public class PredictionService {
 
     private void updatePredictor(Long predictorId) {
         PredictorState state = predictorRepository.getForUpdate(predictorId);
+        if (state.moreUtilizations == false) {
+            log.debug("Another cluster node already updated predictor ID {} (type {} for {}), skipping...", state.predictorId, state.predictorType, state.utilizationKey);
+            return;
+        }
         state.moreUtilizations = false; // by default mark everything as processed, but allow the predictor to override it (and uninstalled predictors get disabled)
         getPredictor(state.predictorType).ifPresent(predictor -> {
             // TODO: consider the update interval of prediction types? or leave that up to the predictor?


### PR DESCRIPTION
This fix should remove the ERROR messages appearing in logs when cluster nodes update predictions, but another node has already updated them. The problem was cause by the fact that the coded did not check if a predictor was already updated. This resulted in a situation where (in a 2 node cluster) another node updated predictions and then the other tried to do the same, but failed to insert the predictions to the database because database constraint (correctly) prevented it.

Even after this fix it is possible that two nodes try to update the same predictor at the same time and another one will fail because the process starts by acquiring an exclusive row-level lock (select for update) on predictor table (to protect against concurrent update attempts). However, that should be much more rare than the certain once-every-5-minutes ERROR logs with exceptions fixed by this PR, and graceful handling for that race condition shall be implemented as a separate PR. 