### PR TITLE
Log to file also for willow deployments

### DIFF
--- a/application/src/main/resources/logback-appenderConsole.xml
+++ b/application/src/main/resources/logback-appenderConsole.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+
+  <property name="LOG_PATTERN"
+            value="%date{&quot;yyyy-MM-dd'T'HH:mm:ss,SSSXXX&quot;} %-5level [%X{srcip}] [%X{username}] [%X{requestid}] [%X{appid}] [%thread] %-40.40logger{39} - %msg %rEx{full}%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+</included>

--- a/application/src/main/resources/logback-appenderWillow.xml
+++ b/application/src/main/resources/logback-appenderWillow.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+
+  <appender name="WILLOW" class="com.nitorcreations.willow.logging.logback.WebSocketAppender">
+    <uri>${wslogging.url}</uri>
+  </appender>
+
+</included>

--- a/application/src/main/resources/logback-logging.profile_IS_UNDEFINED.xml
+++ b/application/src/main/resources/logback-logging.profile_IS_UNDEFINED.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
 
-    <property name="LOG_PATTERN"
-              value="%date{&quot;yyyy-MM-dd'T'HH:mm:ss,SSSXXX&quot;} %-5level [%X{srcip}] [%X{username}] [%X{requestid}] [%X{appid}] [%thread] %-40.40logger{39} - %msg %rEx{full}%n"/>
-
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <charset>UTF-8</charset>
-            <pattern>${LOG_PATTERN}</pattern>
-        </encoder>
-    </appender>
+    <include resource="logback-appenderConsole.xml"/>
 
     <logger name="fi.hsl.parkandride" level="INFO"/>
     <logger name="org.springframework" level="INFO"/>

--- a/application/src/main/resources/logback-willow.xml
+++ b/application/src/main/resources/logback-willow.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
 
-    <appender name="WILLOW" class="com.nitorcreations.willow.logging.logback.WebSocketAppender">
-        <uri>${wslogging.url}</uri>
-    </appender>
+    <include resource="logback-appenderConsole.xml"/>
+    <include resource="logback-appenderWillow.xml"/>
 
     <logger name="fi.hsl.parkandride" level="INFO"/>
     <logger name="org.springframework" level="INFO"/>
 
     <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="WILLOW"/>
     </root>
 


### PR DESCRIPTION
Previously, application logs were only set to willow and not logged to file on the servers. NOTE: willow setting `skipOutputRedirect` needs to be set to `true` to prevent duplicate logging in willow 