### PR TITLE
Fix: predictor update synchronization in cluster

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/core/service/ConcurrentAccessException.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/ConcurrentAccessException.java
@@ -1,0 +1,10 @@
+// Copyright © 2015 HSL <https://www.hsl.fi>
+// This program is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.
+
+package fi.hsl.parkandride.core.service;
+
+public class ConcurrentAccessException extends RuntimeException {
+    public ConcurrentAccessException(String s, Throwable t) {
+        super(s, t);
+    }
+}

--- a/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
@@ -108,7 +108,7 @@ public class PredictionService {
     public void updatePredictions() {
         log.info("updatePredictions");
         TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
-        txTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED); // TODO: set in Core/JdbcConfiguration
+        txTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_SERIALIZABLE); // TODO: set in Core/JdbcConfiguration
         txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 
         for (Long predictorId : findPredictorsNeedingUpdate()) {

--- a/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/PredictionService.java
@@ -108,7 +108,7 @@ public class PredictionService {
     public void updatePredictions() {
         log.info("updatePredictions");
         TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
-        txTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_SERIALIZABLE); // TODO: set in Core/JdbcConfiguration
+        txTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_REPEATABLE_READ); // TODO: set in Core/JdbcConfiguration
         txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 
         for (Long predictorId : findPredictorsNeedingUpdate()) {


### PR DESCRIPTION
This change aims to ensure that all cluster nodes notice if another node has started updating a predictor by promoting transaction isolation to repeatable read isolation level (originally tried serializable). This is an attempt to remove the log error messages (visible only in cluster environment) caused by nodes competing to update predictors.