### PR TITLE
Hide utilization and prediction without corresponding usage in pricing table

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityUtil.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/domain/FacilityUtil.java
@@ -1,0 +1,36 @@
+package fi.hsl.parkandride.core.domain;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Collections.singleton;
+
+public final class FacilityUtil {
+    private FacilityUtil() { /** prevent instantiation */}
+
+    public static Map<CapacityType, Set<Usage>> usagesByCapacityType(Facility facility) {
+        Map<CapacityType, Set<Usage>> usagesByCapacityType = new HashMap<>();
+
+        if (facility.pricingMethod == PricingMethod.PARK_AND_RIDE_247_FREE) {
+            facility.builtCapacity.keySet().forEach(k -> usagesByCapacityType.put(k, singleton(Usage.PARK_AND_RIDE)));
+        } else {
+            facility.pricing.stream().forEach(pricing ->
+                    usagesByCapacityType
+                            .computeIfAbsent(pricing.capacityType, c -> newHashSet())
+                            .add(pricing.usage)
+            );
+        }
+        return usagesByCapacityType;
+    }
+
+    public static <T, C extends Collection<T>> BiFunction<C, C, C> combine() {
+        return (left, right) -> {
+            left.addAll(right);
+            return left;
+        };
+    }
+}

--- a/application/src/main/java/fi/hsl/parkandride/core/service/FacilityService.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/service/FacilityService.java
@@ -17,6 +17,7 @@ import java.util.*;
 
 import static fi.hsl.parkandride.core.domain.Permission.*;
 import static fi.hsl.parkandride.core.service.AuthenticationService.authorize;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 
 public class FacilityService {
@@ -161,10 +162,11 @@ public class FacilityService {
     @TransactionalRead
     public Set<Utilization> findLatestUtilization(long facilityId) {
         final Facility facility = getFacility(facilityId);
+        final Map<CapacityType, Set<Usage>> usagesByCapacityType = FacilityUtil.usagesByCapacityType(facility);
         return utilizationRepository.findLatestUtilization(facilityId)
                 .stream()
+                .filter(u -> usagesByCapacityType.getOrDefault(u.capacityType, emptySet()).contains(u.usage))
                 .filter(u -> facility.builtCapacity.getOrDefault(u.capacityType, 0) > 0)
-                .filter(u -> facility.usages.contains(u.usage))
                 .collect(toSet());
     }
 }

--- a/etc/protractor/specs/facilities/facilityView.spec.js
+++ b/etc/protractor/specs/facilities/facilityView.spec.js
@@ -50,7 +50,10 @@ describe('facility view', function () {
 
     describe('with full data', function () {
         beforeEach(function () {
-            f = toView(facFull, true);
+            var fac = facFull.copy();
+            fac.pricing.push({"capacityType":"CAR","usage":"COMMERCIAL","maxCapacity":5,"dayType":"SATURDAY",
+                "time":{"from":"08","until":"18"},"price":"1e"});
+            f = toView(fac, true);
         });
 
         it('displays full data', function () {
@@ -65,10 +68,13 @@ describe('facility view', function () {
             expect(viewPage.isPredictionsDisplayed()).toBe(true);
             // 4 since devApi creates four rows. Two for CAR, one for DISABLED and ELECTIC_CAR
             // See fi.hsl.parkandride.dev.DevController#generateUtilizationData
-            expect(viewPage.predictionsTable.getSize()).toBe(4);
+            expect(viewPage.predictionsTable.getSize()).toBe(7);
             // The second row is empty: we don't want repeated titles
-            expect(viewPage.predictionsTable.getTypes()).toEqual(['Henkilöauto', '', 'Invapaikka', 'Sähköauto']);
-            expect(viewPage.predictionsTable.getUsages()).toEqual(['Liityntä', 'Kaupallinen', 'Liityntä', 'Liityntä']);
+            expect(viewPage.predictionsTable.getTypes()).toEqual(
+                ['Henkilöauto', '', 'Invapaikka', 'Sähköauto', 'Moottoripyörä', 'Polkupyörä', 'Polkupyörä, lukittu tila']);
+            expect(viewPage.predictionsTable.getUsages()).toEqual(
+                ['Liityntä', 'Kaupallinen', 'Kaupallinen', 'Kaupallinen', 'Liityntä', 'Liityntä', 'Kaupallinen']
+            );
 
             expect(viewPage.isServicesDisplayed()).toBe(true);
             expect(viewPage.getServices()).toEqual("Valaistus, Katettu");
@@ -86,6 +92,9 @@ describe('facility view', function () {
                 {capacityType: "Henkilöauto", usage: "Liityntä", maxCapacity: "10",
                     dayType: "Arkipäivä", is24h: "✓", from: "", until: "",
                     isFree: "✓", priceFi: "", priceSv: "", priceEn: ""},
+                {capacityType: "", usage: "Kaupallinen", maxCapacity: "5",
+                    dayType: "Lauantai", is24h: "", from: "08", until: "18",
+                    isFree: "", priceFi: "1e", priceSv: "1e", priceEn: "1e"},
                 {capacityType: "Invapaikka", usage: "Kaupallinen", maxCapacity: "40",
                     dayType: "Lauantai", is24h: "", from: "08", until: "18",
                     isFree: "", priceFi: "price fi", priceSv: "price sv", priceEn: "price en"},
@@ -105,6 +114,7 @@ describe('facility view', function () {
 
             expect(viewPage.getUnavailableCapacities()).toEqual([
                 {capacityType: "Henkilöauto", usage: "Liityntä", capacity: "1"},
+                {capacityType: "", usage: "Kaupallinen", capacity: "0"},
                 {capacityType: "Invapaikka", usage: "Kaupallinen", capacity: "0"},
                 {capacityType: "Sähköauto", usage: "Kaupallinen", capacity: "0"},
                 {capacityType: "Moottoripyörä", usage: "Liityntä", capacity: "0"},


### PR DESCRIPTION
Previously, utilizations were incorrectly shown if any of the capacity
types had pricing for a given usage. E.g., if a facility had capacities
for CAR and ELECTRIC_CAR with corresponding registered utilizations for
PARK_AND_RIDE and COMMERCIAL usages, the utilization and prediction
endpoints would show all four combinations even if, e.g., ELECTRIC_CAR
would only have PARK_AND_RIDE in the pricing table.