### PR TITLE
Mutex lock improvements

### DIFF
--- a/application/src/main/java/fi/hsl/parkandride/back/LockDao.java
+++ b/application/src/main/java/fi/hsl/parkandride/back/LockDao.java
@@ -48,7 +48,7 @@ public class LockDao implements LockRepository {
         Optional<Lock> lock = selectLockIfExists(lockName);
         if (lock.isPresent()) {
             Lock existingLock = lock.get();
-            if (existingLock.validUntil.isBefore(DateTime.now())) {
+            if (!existingLock.validUntil.isAfter(DateTime.now())) {
                 return claimExpiredLock(existingLock, lockDuration);
             } else {
                 throw new LockAcquireFailedException("Existing lock " + existingLock + " is still valid");

--- a/application/src/main/java/fi/hsl/parkandride/core/back/LockRepository.java
+++ b/application/src/main/java/fi/hsl/parkandride/core/back/LockRepository.java
@@ -10,5 +10,5 @@ public interface LockRepository {
 
     Lock acquireLock(String lockName, Duration lockDuration);
 
-    void releaseLock(Lock lock);
+    boolean releaseLock(Lock lock);
 }

--- a/application/src/test/java/fi/hsl/parkandride/core/service/PredictionServiceTest.java
+++ b/application/src/test/java/fi/hsl/parkandride/core/service/PredictionServiceTest.java
@@ -122,6 +122,7 @@ public class PredictionServiceTest extends AbstractDaoTest {
         assertThat(spy.getMaxConcurrentPredictors()).as("max concurrent predictors").isEqualTo(1);
     }
 
+    /* Disabled concurrent updates due to concurrency problems in cluster
     @Test
     public void allows_updating_different_predictors_concurrently() throws InterruptedException {
         ConcurrentPredictorsSpy spy = new ConcurrentPredictorsSpy();
@@ -136,7 +137,7 @@ public class PredictionServiceTest extends AbstractDaoTest {
 
         assertThat(spy.getMaxConcurrentPredictors()).as("max concurrent predictors").isEqualTo(2);
     }
-
+    */
 
     // helpers
 


### PR DESCRIPTION
Changed predictor updating so that cluster nodes first compete for a mutually exclusive lock on which node gets the right to update the predictors. Added more unit tests for the mutex locks and fix lock releasing so that trying to release an expired lock does not delete possible new and valid lock even if the new lock is owned by the same node.